### PR TITLE
feature/EODHP-71-deploy-argo-cd-to-test-cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,5 @@
 # Change Log
+
+## v0.1.0
+
+- Created the simplest self-managed AgroCD deployment possible; single environment with two apps, ArgoCD itself and a demo Guestbook app. Guestbook app should be removed in subsequent releases.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,40 @@
 # EO DataHub Platform ArgoCD Deployment
 
 This is the deployment repo for the UK EO DataHub Platform. The deployment uses the ArgoCD GitOps framework.
+
+## ArgoCD
+
+The applications deployed by this repo are designed to be managed by the ArgoCD GitOps framework. This deployment follows the app of apps pattern, where there is one "root" app that points to many child apps.
+
+One of the apps deployed is ArgoCD itself, so that ArgoCD manages itself. For this to work, ArgoCD must already be installed on the cluster, manually or otherwise, to which the root app is deployed. After that, ArgoCD will manage its own deployment.
+
+The version of ArgoCD bootstrapped in the cluster must match that of the root app.
+
+### App of Apps
+
+The app of apps pattern is used to deploy many ArgoCD applications together. The root app, _app.yaml_, points to a target Git repository and revision containing the source of truth for the application deployment. The target repo is the deployment's own repository. An additional path points to more applications within the repository, which are then deployed as child applications of the root app.
+
+### Bootstrap ArgoCD
+
+In the ArgoCD deployment, ArgoCD is deployed via Helm chart. To bootstrap the deployment it must initially be deployed to the cluster, so that it may manage its own deployment. This initial bootstrapping can be done manually, or it can be automated as part of the cluster setup.
+
+To install ArgoCD to the cluster manually:
+
+```bash
+helm repo add argocd https://argoproj.github.io/argo-helm
+helm install argocd argocd/argo-cd --version VERSION
+```
+
+Ensure that VERSION matches the version stated in the relevant _apps/\*\*/argocd/argocd.yaml_ `spec.source.targetRevision` for your deployment environment.
+
+Once you have installed ArgoCD to the cluster you can then apply the root app manifest to the cluster:
+
+```bash
+kubectl apply -f app.yaml
+```
+
+At this point ArgoCD will now be managing itself.
+
+### ArgoCD CRDs
+
+All ArgoCD Application CRD manifests should be deployed to the namespace ArgoCD, e.g. Any Application CRDs. Otherwise, they will not be picked up and implemented by ArgoCD.

--- a/app.yaml
+++ b/app.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+ name: eodhp
+ namespace: argocd     
+spec:
+ project: default
+ destination:
+   namespace: default
+   server: https://kubernetes.default.svc
+ source:
+   repoURL: https://github.com/UKEODHP/eodhp-argocd-deployment.git
+   targetRevision: feature/EODHP-71-deploy-argo-cd-to-test-cluster
+   path: apps/
+ syncPolicy:
+   automated:
+     prune: false 
+     selfHeal: true 
+     allowEmpty: false
+   syncOptions:
+     - CreateNamespace=true

--- a/apps/argocd/argocd.yaml
+++ b/apps/argocd/argocd.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd
+  namespace: argocd      
+spec:
+  project: default
+  destination:
+    namespace: argocd
+    server: https://kubernetes.default.svc
+  source:
+    chart: argo-cd
+    repoURL: https://argoproj.github.io/argo-helm
+    targetRevision: 5.53.11
+    helm:
+      releaseName: argocd
+  syncPolicy:
+    automated:
+      prune: false 
+      selfHeal: true 
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/argocd/kustomization.yaml
+++ b/apps/argocd/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- argocd.yaml

--- a/apps/guestbook/guestbook.yaml
+++ b/apps/guestbook/guestbook.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: guestbook
+  namespace: argocd   
+spec:
+  project: default
+  destination:
+    namespace: guestbook
+    server: https://kubernetes.default.svc
+  source:
+    repoURL: https://github.com/argoproj/argocd-example-apps.git
+    targetRevision: HEAD
+    path: guestbook/
+  syncPolicy:
+    automated:
+      prune: true 
+      selfHeal: true 
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/guestbook/kustomization.yaml
+++ b/apps/guestbook/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- guestbook.yaml

--- a/apps/kustomization.yaml
+++ b/apps/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- argocd
+- guestbook


### PR DESCRIPTION
This pull request is a first deployment of ArgoCD. The current state is the simplest instance possible where ArgoCD manages itself via App of Apps method. There is only one environment at the moment, future releases will split the repo so that multiple environments can be managed from the same repo.

An example app (guestbook) was deployed as a child app as an example to prove the concept. This will be removed as soon as we add an EODHP app.

The app needs to either be bootstrapped manually (instructions in readme), or via accompanying terraform script.