### PR TITLE
bugfix/EODHP-156-automate-efs-file-system-id-in-argo-cd

### DIFF
--- a/apps/storage/efs-sc.yaml
+++ b/apps/storage/efs-sc.yaml
@@ -1,9 +1,0 @@
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: efs-sc
-provisioner: efs.csi.aws.com
-parameters:
-  provisioningMode: efs-ap
-  fileSystemId: fs-0e5146aa40b383958
-  directoryPerms: "700"

--- a/apps/storage/kustomization.yaml
+++ b/apps/storage/kustomization.yaml
@@ -1,5 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-resources:
-  - efs-sc.yaml

--- a/eodhp/apps.yaml
+++ b/eodhp/apps.yaml
@@ -7,7 +7,7 @@ spec:
   generators:
     - git:
         repoURL: https://github.com/UKEODHP/eodhp-argocd-deployment.git
-        revision: HEAD
+        revision: bugfix/EODHP-156-automate-efs-file-system-id-in-argo-cd
         directories:
           - path: "apps/*"
           - path: "apps/argocd"
@@ -19,7 +19,7 @@ spec:
       project: default
       source:
         repoURL: https://github.com/UKEODHP/eodhp-argocd-deployment.git
-        targetRevision: HEAD
+        targetRevision: bugfix/EODHP-156-automate-efs-file-system-id-in-argo-cd
         path: "{{path}}"
       destination:
         server: https://kubernetes.default.svc

--- a/eodhp/argocd-app.yaml
+++ b/eodhp/argocd-app.yaml
@@ -10,7 +10,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/UKEODHP/eodhp-argocd-deployment.git
-    targetRevision: HEAD
+    targetRevision: bugfix/EODHP-156-automate-efs-file-system-id-in-argo-cd
     path: apps/argocd
   syncPolicy:
     automated:


### PR DESCRIPTION
Storage class file system ID needed to be updated manually each deployment, which caused cluster to hang if it was forgotten. I updated Terraform to install Storage Class for the EFS storage it creates and removed ArgoCD storage app. ArgoCD PVCs still refer to known SC name as before.