### PR TITLE
feature/EODHP-74-deploy-cert-manager-and-ca-to-cluster

### DIFF
--- a/apps/eoxvs/kustomization.yaml
+++ b/apps/eoxvs/kustomization.yaml
@@ -18,10 +18,20 @@ patches:
   - target:
       kind: Ingress
     patch: |-
-      # update resource catalogue to use spec.ingressClassName instead of annotation
+      # Update resource catalogue to use spec.ingressClassName instead of annotation
       # "kubernetes.io/ingress.class"
       - op: remove
         path: /metadata/annotations/kubernetes.io~1ingress.class
       - op: add
         path: /spec/ingressClassName
         value: nginx
+  - target:
+      kind: Ingress
+    patch: |-
+      # Set TLS secret name
+      - op: add
+        path: /spec/tls/0/secretName
+        value: lets-encrypt
+      - op: add
+        path: /metadata/annotations/cert-manager.io~1cluster-issuer
+        value: lets-encrypt

--- a/apps/web-presence/kustomization.yaml
+++ b/apps/web-presence/kustomization.yaml
@@ -12,3 +12,18 @@ helmCharts:
     releaseName: web-presence
     version: 0.1.0
     valuesFile: values.yaml
+
+patches:
+  - target:
+      kind: Ingress
+    patch: |-
+      # Set TLS secret name
+      - op: add
+        path: /spec/tls
+        value: 
+          - hosts: 
+              - dev.eodhp.eco-ke-staging.com
+            secretName: lets-encrypt
+      - op: add
+        path: /metadata/annotations/cert-manager.io~1cluster-issuer
+        value: lets-encrypt

--- a/eodhp/apps.yaml
+++ b/eodhp/apps.yaml
@@ -7,7 +7,7 @@ spec:
   generators:
     - git:
         repoURL: https://github.com/UKEODHP/eodhp-argocd-deployment.git
-        revision: bugfix/EODHP-169-swap-aws-alb-controller-for-nginx-ingress-controller
+        revision: feature/EODHP-74-deploy-cert-manager-and-ca-to-cluster
         directories:
           - path: "apps/*"
           - path: "apps/argocd"
@@ -19,7 +19,7 @@ spec:
       project: default
       source:
         repoURL: https://github.com/UKEODHP/eodhp-argocd-deployment.git
-        targetRevision: bugfix/EODHP-169-swap-aws-alb-controller-for-nginx-ingress-controller
+        targetRevision: feature/EODHP-74-deploy-cert-manager-and-ca-to-cluster
         path: "{{path}}"
       destination:
         server: https://kubernetes.default.svc

--- a/eodhp/argocd-app.yaml
+++ b/eodhp/argocd-app.yaml
@@ -10,7 +10,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/UKEODHP/eodhp-argocd-deployment.git
-    targetRevision: bugfix/EODHP-169-swap-aws-alb-controller-for-nginx-ingress-controller
+    targetRevision: feature/EODHP-74-deploy-cert-manager-and-ca-to-cluster
     path: apps/argocd
   syncPolicy:
     automated:


### PR DESCRIPTION
PR to add TLS encryption to the cluster. The changes in this PR relate to patching the existing apps to request TLS certificates.

Other PRs are outstanding so there are additional changes visible in this PR at the moment. The files to looks at are apps/*/kustomization.yaml, specifically the patches regarding cert-manager annotation and tls secretName.