### PR TITLE
feature/EODHP-145-adequate-kubernetes-secrets-management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,22 @@
 # Change Log
 
-## v0.1.0
+## v0.3.2
 
-- Created the simplest self-managed ArgoCD deployment possible; single environment with two apps, ArgoCD itself and a demo Guestbook app. Guestbook app should be removed in subsequent releases.
+- Demonstrated importing secret in web-presence from secret-store
+
+## v0.3.1
+
+- Swapped AWS ALB for Ingress Nginx Controller due to limitations of AWS ALB routing (no rewrites)
+
+## v0.3.0
+
+- Added web presence app (content management system)
 
 ## v0.2.0
 
 - Refactored directory structure and bootstrap procedure to fix ArgoCD stability issues
 - Added EOxVS and removed the demo guestbook app
 
-## v0.3.0
+## v0.1.0
 
-- Added web presence app (content management system)
-
-## v0.3.1
-
-- Swapped AWS ALB for Ingress Nginx Controller due to limitations of AWS ALB routing (no rewrites)
+- Created the simplest self-managed ArgoCD deployment possible; single environment with two apps, ArgoCD itself and a demo Guestbook app. Guestbook app should be removed in subsequent releases.

--- a/README.md
+++ b/README.md
@@ -49,3 +49,19 @@ You should now be able to access the UI on http://127.0.0.1:8080. The default us
 ### ArgoCD CRDs
 
 All ArgoCD Application CRD manifests should be deployed to the namespace ArgoCD, e.g. Any Application CRDs. Otherwise, they will not be picked up and implemented by ArgoCD.
+
+## Cluster Prerequisites
+
+The EO DataHub Platform deployment expects the following resources to be available on the cluster.
+
+### Storage Classes
+
+- "file-storage" : for NFS like file system storage that can be shared between pods.
+
+### Ingress Class
+
+- "nginx" : The ingress-nginx (https://kubernetes.github.io/ingress-nginx) ingress controller.
+
+### Secret Stores
+
+- "secret-store" : A ClusterSecretStore from external-secrets helm chart (https://charts.external-secrets.io).

--- a/apps/eoxvs/kustomization.yaml
+++ b/apps/eoxvs/kustomization.yaml
@@ -18,10 +18,20 @@ patches:
   - target:
       kind: Ingress
     patch: |-
-      # update resource catalogue to use spec.ingressClassName instead of annotation
+      # Update resource catalogue to use spec.ingressClassName instead of annotation
       # "kubernetes.io/ingress.class"
       - op: remove
         path: /metadata/annotations/kubernetes.io~1ingress.class
       - op: add
         path: /spec/ingressClassName
         value: nginx
+  - target:
+      kind: Ingress
+    patch: |-
+      # Set TLS secret name
+      - op: add
+        path: /spec/tls/0/secretName
+        value: lets-encrypt
+      - op: add
+        path: /metadata/annotations/cert-manager.io~1cluster-issuer
+        value: lets-encrypt

--- a/apps/eoxvs/redis-pvc.yaml
+++ b/apps/eoxvs/redis-pvc.yaml
@@ -3,7 +3,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: data-access-redis
 spec:
-  storageClassName: efs-sc
+  storageClassName: file-storage
   accessModes:
     - ReadWriteOnce
   resources:

--- a/apps/web-presence/kustomization.yaml
+++ b/apps/web-presence/kustomization.yaml
@@ -12,3 +12,18 @@ helmCharts:
     releaseName: web-presence
     version: 0.1.0
     valuesFile: values.yaml
+
+patches:
+  - target:
+      kind: Ingress
+    patch: |-
+      # Set TLS secret name
+      - op: add
+        path: /spec/tls
+        value: 
+          - hosts: 
+              - dev.eodhp.eco-ke-staging.com
+            secretName: lets-encrypt
+      - op: add
+        path: /metadata/annotations/cert-manager.io~1cluster-issuer
+        value: lets-encrypt

--- a/apps/web-presence/kustomization.yaml
+++ b/apps/web-presence/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: web
 
 resources:
   - namespace.yaml
+  - secrets.yaml
 
 helmCharts:
   - name: eodhp-web-presence

--- a/apps/web-presence/secrets.yaml
+++ b/apps/web-presence/secrets.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: web-presence
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: secret-store
+    kind: ClusterSecretStore
+  target:
+    name: web-presence
+  data:
+    - secretKey: web-presence.sql_password
+      remoteRef:
+        key: eodhp-dev
+        property: "web-presence.sql_password"

--- a/apps/web-presence/values.yaml
+++ b/apps/web-presence/values.yaml
@@ -10,4 +10,4 @@ ingress:
 resource_catalogue:
   version: v1.2.3
 
-storage_class: efs-sc
+storage_class: file-storage

--- a/eodhp/apps.yaml
+++ b/eodhp/apps.yaml
@@ -7,7 +7,7 @@ spec:
   generators:
     - git:
         repoURL: https://github.com/UKEODHP/eodhp-argocd-deployment.git
-        revision: feature/EODHP-74-deploy-cert-manager-and-ca-to-cluster
+        revision: feature/EODHP-145-adequate-kubernetes-secrets-management
         directories:
           - path: "apps/*"
           - path: "apps/argocd"
@@ -19,7 +19,7 @@ spec:
       project: default
       source:
         repoURL: https://github.com/UKEODHP/eodhp-argocd-deployment.git
-        targetRevision: feature/EODHP-74-deploy-cert-manager-and-ca-to-cluster
+        targetRevision: feature/EODHP-145-adequate-kubernetes-secrets-management
         path: "{{path}}"
       destination:
         server: https://kubernetes.default.svc

--- a/eodhp/apps.yaml
+++ b/eodhp/apps.yaml
@@ -7,7 +7,7 @@ spec:
   generators:
     - git:
         repoURL: https://github.com/UKEODHP/eodhp-argocd-deployment.git
-        revision: bugfix/EODHP-169-swap-aws-alb-controller-for-nginx-ingress-controller
+        revision: feature/EODHP-74-deploy-cert-manager-and-ca-to-cluster
         directories:
           - path: "apps/*"
           - path: "apps/argocd"
@@ -19,7 +19,7 @@ spec:
       project: default
       source:
         repoURL: https://github.com/UKEODHP/eodhp-argocd-deployment.git
-        targetRevision: bugfix/EODHP-169-swap-aws-alb-controller-for-nginx-ingress-controller
+        targetRevision: feature/EODHP-74-deploy-cert-manager-and-ca-to-cluster
         path: "{{path}}"
       destination:
         server: https://kubernetes.default.svc

--- a/eodhp/argocd-app.yaml
+++ b/eodhp/argocd-app.yaml
@@ -10,7 +10,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/UKEODHP/eodhp-argocd-deployment.git
-    targetRevision: feature/EODHP-74-deploy-cert-manager-and-ca-to-cluster
+    targetRevision: feature/EODHP-145-adequate-kubernetes-secrets-management
     path: apps/argocd
   syncPolicy:
     automated:

--- a/eodhp/argocd-app.yaml
+++ b/eodhp/argocd-app.yaml
@@ -10,7 +10,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/UKEODHP/eodhp-argocd-deployment.git
-    targetRevision: bugfix/EODHP-169-swap-aws-alb-controller-for-nginx-ingress-controller
+    targetRevision: feature/EODHP-74-deploy-cert-manager-and-ca-to-cluster
     path: apps/argocd
   syncPolicy:
     automated:


### PR DESCRIPTION
PR to add ability to get secrets from a cluster secret store, avoiding the need to create secrets in the cluster manually or store them in Git.

An example of how to retrieve a secret from the secret store has been included as part of this PR for the web-presence app.

Some changes from other PRs are included in this PR, the only relevant files required for review are the readme, apps/web-presence/kustomization.yaml and apps/web-presence/secrets.yaml