### PR TITLE
feature/EODHP-154-swap-e-ox-vs-redis-cache-to-ebs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.4.0
 
 - Updated repo directory structure to support multi environment deployments
+- Swapped apps to use block-storage storage class
 
 ## v0.3.2
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The EO DataHub Platform deployment expects the following resources to be availab
 
 ### Storage Classes
 
+- "block-storage" : for local pod persistent storage.
 - "file-storage" : for NFS like file system storage that can be shared between pods.
 
 ### Ingress Class

--- a/apps/eoxvs/base/redis-pvc.yaml
+++ b/apps/eoxvs/base/redis-pvc.yaml
@@ -3,7 +3,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: data-access-redis
 spec:
-  storageClassName: file-storage
+  storageClassName: block-storage
   accessModes:
     - ReadWriteOnce
   resources:

--- a/apps/web-presence/base/values.yaml
+++ b/apps/web-presence/base/values.yaml
@@ -10,4 +10,4 @@ ingress:
 resource_catalogue:
   version: v1.2.3
 
-storage_class: file-storage
+storage_class: block-storage

--- a/apps/web-presence/envs/dev/values.yaml
+++ b/apps/web-presence/envs/dev/values.yaml
@@ -10,4 +10,4 @@ ingress:
 resource_catalogue:
   version: v1.2.3
 
-storage_class: file-storage
+storage_class: block-storage

--- a/apps/web-presence/envs/test/values.yaml
+++ b/apps/web-presence/envs/test/values.yaml
@@ -10,4 +10,4 @@ ingress:
 resource_catalogue:
   version: v1.2.3
 
-storage_class: file-storage
+storage_class: block-storage


### PR DESCRIPTION
PR to use block storage instead of file storage for components that only require local pod storage.

This change is to the ArgoCD deployments to point them to the new block-storage storage class created by Terraform.

Changes have been tested in the dev cluster and PVs are dynamically created from block-storage PVCs correctly.
