### PR TITLE
feature/EODHP-3-iam-user-sso-login

### DIFF
--- a/apps/eoxvs/base/redis-pvc.yaml
+++ b/apps/eoxvs/base/redis-pvc.yaml
@@ -3,7 +3,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: data-access-redis
 spec:
-  storageClassName: file-storage
+  storageClassName: block-storage
   accessModes:
     - ReadWriteOnce
   resources:

--- a/apps/eoxvs/envs/dev/kustomization.yaml
+++ b/apps/eoxvs/envs/dev/kustomization.yaml
@@ -27,10 +27,6 @@ patches:
   - target:
       kind: Ingress
     patch: |-
-      # Set TLS secret name
-      - op: add
-        path: /spec/tls/0/secretName
-        value: lets-encrypt
       - op: add
         path: /metadata/annotations/cert-manager.io~1cluster-issuer
         value: lets-encrypt

--- a/apps/eoxvs/envs/dev/values.yaml
+++ b/apps/eoxvs/envs/dev/values.yaml
@@ -445,7 +445,7 @@ global:
     tls:
       - hosts:
           - vs.dev.eodhp.eco-ke-staging.com
-        secretName: lets-encrypt
+        secretName: vs.dev.eodhp.eco-ke-staging.com-tls
       # hosts and tls will be redefined always
     prefix:
       enabled: false

--- a/apps/eoxvs/envs/dev/values.yaml
+++ b/apps/eoxvs/envs/dev/values.yaml
@@ -445,7 +445,7 @@ global:
     tls:
       - hosts:
           - vs.dev.eodhp.eco-ke-staging.com
-        secretName: vs-secret
+        secretName: lets-encrypt
       # hosts and tls will be redefined always
     prefix:
       enabled: false
@@ -586,15 +586,15 @@ client:
         hidden: true
     downloadFormats:
       [
-        { "name": "TIFF", "mimeType": "image/tiff" },
-        { "name": "JPEG 2000", "mimeType": "image/jp2" },
-        { "name": "HDF", "mimeType": "application/x-hdf" },
+        {"name": "TIFF", "mimeType": "image/tiff"},
+        {"name": "JPEG 2000", "mimeType": "image/jp2"},
+        {"name": "HDF", "mimeType": "application/x-hdf"},
       ]
     multiDownloadFormats:
       [
-        { "name": "ZIP", "mimeType": "application/zip" },
-        { "name": "TAR", "mimeType": "application/tar" },
-        { "name": "GZIP", "mimeType": "application/gzip" },
+        {"name": "ZIP", "mimeType": "application/zip"},
+        {"name": "TAR", "mimeType": "application/tar"},
+        {"name": "GZIP", "mimeType": "application/gzip"},
       ]
     downloadProjections:
       [

--- a/apps/eoxvs/envs/test/kustomization.yaml
+++ b/apps/eoxvs/envs/test/kustomization.yaml
@@ -27,10 +27,6 @@ patches:
   - target:
       kind: Ingress
     patch: |-
-      # Set TLS secret name
-      - op: add
-        path: /spec/tls/0/secretName
-        value: lets-encrypt
       - op: add
         path: /metadata/annotations/cert-manager.io~1cluster-issuer
         value: lets-encrypt

--- a/apps/eoxvs/envs/test/values.yaml
+++ b/apps/eoxvs/envs/test/values.yaml
@@ -445,7 +445,7 @@ global:
     tls:
       - hosts:
           - vs.test.eodhp.eco-ke-staging.com
-        secretName: lets-encrypt
+        secretName: vs.test.eodhp.eco-ke-staging.com-tls
       # hosts and tls will be redefined always
     prefix:
       enabled: false

--- a/apps/eoxvs/envs/test/values.yaml
+++ b/apps/eoxvs/envs/test/values.yaml
@@ -445,7 +445,7 @@ global:
     tls:
       - hosts:
           - vs.test.eodhp.eco-ke-staging.com
-        secretName: vs-secret
+        secretName: lets-encrypt
       # hosts and tls will be redefined always
     prefix:
       enabled: false

--- a/apps/keycloak/base/kustomization.yaml
+++ b/apps/keycloak/base/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: keycloak
+
+resources:
+  - namespace.yaml
+

--- a/apps/keycloak/base/namespace.yaml
+++ b/apps/keycloak/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: keycloak

--- a/apps/keycloak/envs/dev/kustomization.yaml
+++ b/apps/keycloak/envs/dev/kustomization.yaml
@@ -14,10 +14,3 @@ helmCharts:
     version: 17.3.6
     valuesFile: "values.yaml"
 
-patches:
-  - target:
-      kind: Ingress
-    patch: |-
-      - op: add
-        path: /metadata/annotations/cert-manager.io~1cluster-issuer
-        value: lets-encrypt

--- a/apps/keycloak/envs/dev/kustomization.yaml
+++ b/apps/keycloak/envs/dev/kustomization.yaml
@@ -12,18 +12,12 @@ helmCharts:
     repo: oci://registry-1.docker.io/bitnamicharts/
     releaseName: keycloak
     version: 17.3.6
-    valuesInline:
-      auth:
-        adminUser: admin
-        existingSecret: keycloak
-        passwordSecretKey: password
-      postgresql:
-        auth:
-          database: keycloak
-          username: keycloak
-          existingSecret: keycloak
-      ingress:
-        enabled: true
-        ingressClassName: nginx
-        hostname: keycloak.dev.eodhp.eco-ke-staging.com
-      global.storageClass: block-storage
+    valuesFile: "values.yaml"
+
+patches:
+  - target:
+      kind: Ingress
+    patch: |-
+      - op: add
+        path: /metadata/annotations/cert-manager.io~1cluster-issuer
+        value: lets-encrypt

--- a/apps/keycloak/envs/dev/kustomization.yaml
+++ b/apps/keycloak/envs/dev/kustomization.yaml
@@ -26,12 +26,4 @@ helmCharts:
         enabled: true
         ingressClassName: nginx
         hostname: keycloak.dev.eodhp.eco-ke-staging.com
-      # global.storageClass: file-storage
-
-patches:
-  - target:
-      kind: PersistentVolumeClaim
-    patch: |-
-      - op: replace
-        path: /spec/storageClassName
-        value: file-storage
+      global.storageClass: block-storage

--- a/apps/keycloak/envs/dev/kustomization.yaml
+++ b/apps/keycloak/envs/dev/kustomization.yaml
@@ -1,0 +1,37 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: keycloak
+
+resources:
+  - ../../base
+  - secrets.yaml
+
+helmCharts:
+  - name: keycloak
+    repo: oci://registry-1.docker.io/bitnamicharts/
+    releaseName: keycloak
+    version: 17.3.6
+    valuesInline:
+      auth:
+        adminUser: admin
+        existingSecret: keycloak
+        passwordSecretKey: password
+      postgresql:
+        auth:
+          database: keycloak
+          username: keycloak
+          existingSecret: keycloak
+      ingress:
+        enabled: true
+        ingressClassName: nginx
+        hostname: keycloak.dev.eodhp.eco-ke-staging.com
+      # global.storageClass: file-storage
+
+patches:
+  - target:
+      kind: PersistentVolumeClaim
+    patch: |-
+      - op: replace
+        path: /spec/storageClassName
+        value: file-storage

--- a/apps/keycloak/envs/dev/secrets.yaml
+++ b/apps/keycloak/envs/dev/secrets.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: keycloak
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: secret-store
+    kind: ClusterSecretStore
+  target:
+    name: keycloak
+  data:
+    - secretKey: password
+      remoteRef:
+        key: eodhp-dev
+        property: keycloak.auth.adminPassword
+    - secretKey: postgres-password
+      remoteRef:
+        key: eodhp-dev
+        property: keycloak.auth.postgresPassword

--- a/apps/keycloak/envs/dev/values.yaml
+++ b/apps/keycloak/envs/dev/values.yaml
@@ -12,6 +12,6 @@ ingress:
   enabled: true
   ingressClassName: nginx
   hostname: keycloak.dev.eodhp.eco-ke-staging.com
-tls:
-  enabled: true
-  existingSecret: keycloak
+  annotations:
+    cert-manager.io/cluster-issuer: lets-encrypt
+  tls: true

--- a/apps/keycloak/envs/dev/values.yaml
+++ b/apps/keycloak/envs/dev/values.yaml
@@ -1,0 +1,17 @@
+global.storageClass: block-storage
+auth:
+  adminUser: admin
+  existingSecret: keycloak
+  passwordSecretKey: password
+postgresql:
+  auth:
+    database: keycloak
+    username: keycloak
+    existingSecret: keycloak
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hostname: keycloak.dev.eodhp.eco-ke-staging.com
+tls:
+  enabled: true
+  existingSecret: keycloak

--- a/apps/keycloak/envs/dev/values.yaml
+++ b/apps/keycloak/envs/dev/values.yaml
@@ -15,3 +15,4 @@ ingress:
   annotations:
     cert-manager.io/cluster-issuer: lets-encrypt
   tls: true
+proxy: edge

--- a/apps/web-presence/envs/dev/kustomization.yaml
+++ b/apps/web-presence/envs/dev/kustomization.yaml
@@ -24,7 +24,7 @@ patches:
         value: 
           - hosts: 
               - dev.eodhp.eco-ke-staging.com
-            secretName: lets-encrypt
+            secretName: dev.eodhp.eco-ke-staging.com-tls
       - op: add
         path: /metadata/annotations/cert-manager.io~1cluster-issuer
         value: lets-encrypt

--- a/apps/web-presence/envs/test/kustomization.yaml
+++ b/apps/web-presence/envs/test/kustomization.yaml
@@ -24,7 +24,7 @@ patches:
         value: 
           - hosts: 
               - test.eodhp.eco-ke-staging.com
-            secretName: lets-encrypt
+            secretName: test.eodhp.eco-ke-staging.com-tls
       - op: add
         path: /metadata/annotations/cert-manager.io~1cluster-issuer
         value: lets-encrypt

--- a/apps/web-presence/envs/test/values.yaml
+++ b/apps/web-presence/envs/test/values.yaml
@@ -10,4 +10,4 @@ ingress:
 resource_catalogue:
   version: v1.2.3
 
-storage_class: file-storage
+storage_class: block-storage

--- a/eodhp/envs/dev/kustomization.yaml
+++ b/eodhp/envs/dev/kustomization.yaml
@@ -14,7 +14,7 @@ patches:
         value: apps/*/envs/dev
       - op: replace
         path: /spec/generators/0/git/revision
-        value: feature/EODHP-3-iam-user-sso-login
+        value: HEAD
       - op: replace
         path: /spec/template/spec/source/targetRevision
-        value: feature/EODHP-3-iam-user-sso-login
+        value: HEAD

--- a/eodhp/envs/dev/kustomization.yaml
+++ b/eodhp/envs/dev/kustomization.yaml
@@ -14,7 +14,7 @@ patches:
         value: apps/*/envs/dev
       - op: replace
         path: /spec/generators/0/git/revision
-        value: HEAD
+        value: feature/EODHP-3-iam-user-sso-login
       - op: replace
         path: /spec/template/spec/source/targetRevision
-        value: HEAD
+        value: feature/EODHP-3-iam-user-sso-login


### PR DESCRIPTION
PR to add Keycloak deployment to dev cluster. User should be able to navigate to keycloak.dev.eodhp.eco-ke-staging.com, select the admin console line and login with username admin and keycloak.auth.adminPassword from eodhp-dev secret in AWS Secrets Manager.

Some changes made in another PR have crept in to this one as I cherry picked them across. Files anywhere but apps/keycloak/* can be ignored in this PR.