### PR TITLE
feature/EODHP-148-stac-catalog-tls-and-domain-name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v0.6.0
+
+- Added STAC browser link from web presence
+
 ## v0.5.0
 
 - Added Keycloak app (not integrated with anything)

--- a/apps/web-presence/envs/dev/kustomization.yaml
+++ b/apps/web-presence/envs/dev/kustomization.yaml
@@ -11,7 +11,7 @@ helmCharts:
   - name: eodhp-web-presence
     repo: oci://public.ecr.aws/n1b3o1k2/helm
     releaseName: web-presence
-    version: 0.1.0
+    version: 0.1.1
     valuesFile: values.yaml
 
 patches:

--- a/apps/web-presence/envs/dev/values.yaml
+++ b/apps/web-presence/envs/dev/values.yaml
@@ -11,6 +11,6 @@ eox_viewserver:
   url: http://vs.dev.eodhp.eco-ke-staging.com/
 
 stac_browser:
-  url: http://stac.dev.eodhp.eco-ke-staging.com/
+  url: http://stac.dev.eodhp.eco-ke-staging.com/v3.1.1
 
 storage_class: block-storage

--- a/apps/web-presence/envs/dev/values.yaml
+++ b/apps/web-presence/envs/dev/values.yaml
@@ -7,7 +7,10 @@ database:
 ingress:
   host: dev.eodhp.eco-ke-staging.com
 
-resource_catalogue:
-  version: v1.2.3
+eox_viewserver:
+  url: http://vs.dev.eodhp.eco-ke-staging.com/
+
+stac_browser:
+  url: http://stac.dev.eodhp.eco-ke-staging.com/
 
 storage_class: block-storage


### PR DESCRIPTION
PR to add STAC browser to platform deployment. Added link from web presence to STAC browser.

Note that link won't work until https://github.com/UKEODHP/stac-browser.git PR https://github.com/UKEODHP/stac-browser/pull/2 is merged and released.