### PR TITLE
Feature/eodhp 129 allow workflow to post results to s3

### DIFF
--- a/apps/ades/envs/dev/kustomization.yaml
+++ b/apps/ades/envs/dev/kustomization.yaml
@@ -62,20 +62,20 @@ patches:
             configMapKeyRef:
               name: zoo-project-dru-zoofpm-config
               key: STAGEOUT_OUTPUT
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: STAGEOUT_AWS_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              name: ades-secret
-              key: workflowExecutor.inputs.STAGEOUT_AWS_ACCESS_KEY_ID
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: STAGEOUT_AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              name: ades-secret
-              key: workflowExecutor.inputs.STAGEOUT_AWS_SECRET_ACCESS_KEY
+      # - op: add
+      #   path: /spec/template/spec/containers/0/env/-
+      #   value:
+      #     name: STAGEOUT_AWS_ACCESS_KEY_ID
+      #     valueFrom:
+      #       secretKeyRef:
+      #         name: ades-secret
+      #         key: workflowExecutor.inputs.STAGEOUT_AWS_ACCESS_KEY_ID
+      # - op: add
+      #   path: /spec/template/spec/containers/0/env/-
+      #   value:
+      #     name: STAGEOUT_AWS_SECRET_ACCESS_KEY
+      #     valueFrom:
+      #       secretKeyRef:
+      #         name: ades-secret
+      #         key: workflowExecutor.inputs.STAGEOUT_AWS_SECRET_ACCESS_KEY
   - path: delete-pvc-patch.yaml

--- a/apps/ades/envs/dev/kustomization.yaml
+++ b/apps/ades/envs/dev/kustomization.yaml
@@ -80,22 +80,22 @@ patches:
       #       configMapKeyRef:
       #         name: zoo-project-dru-zoofpm-config
       #         key: STAGEOUT_AWS_ACCESS_KEY_ID
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: STAGEOUT_AWS_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              name: ades-secret
-              key: workflowExecutor.inputs.STAGEOUT_AWS_ACCESS_KEY_ID
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: STAGEOUT_AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              name: ades-secret
-              key: workflowExecutor.inputs.STAGEOUT_AWS_SECRET_ACCESS_KEY
+      # - op: add
+      #   path: /spec/template/spec/containers/0/env/-
+      #   value:
+      #     name: STAGEOUT_AWS_ACCESS_KEY_ID
+      #     valueFrom:
+      #       secretKeyRef:
+      #         name: ades-secret
+      #         key: workflowExecutor.inputs.STAGEOUT_AWS_ACCESS_KEY_ID
+      # - op: add
+      #   path: /spec/template/spec/containers/0/env/-
+      #   value:
+      #     name: STAGEOUT_AWS_SECRET_ACCESS_KEY
+      #     valueFrom:
+      #       secretKeyRef:
+      #         name: ades-secret
+      #         key: workflowExecutor.inputs.STAGEOUT_AWS_SECRET_ACCESS_KEY
       - op: add
         path: /spec/template/spec/serviceAccountName
         value: zoo-project-dru

--- a/apps/ades/envs/dev/kustomization.yaml
+++ b/apps/ades/envs/dev/kustomization.yaml
@@ -21,6 +21,8 @@ configMapGenerator:
       - STAGEOUT_AWS_SERVICEURL=https://s3.eu-west-2.amazonaws.com
       - STAGEOUT_AWS_REGION=eu-west-2
       - STAGEOUT_OUTPUT=eodhp-ades
+      - STAGEOUT_AWS_ACCESS_KEY_ID=""
+      - STAGEOUT_AWS_SECRET_ACCESS_KEY=""
 
 patches:
   - target:
@@ -62,20 +64,20 @@ patches:
             configMapKeyRef:
               name: zoo-project-dru-zoofpm-config
               key: STAGEOUT_OUTPUT
-      # - op: add
-      #   path: /spec/template/spec/containers/0/env/-
-      #   value:
-      #     name: STAGEOUT_AWS_ACCESS_KEY_ID
-      #     valueFrom:
-      #       secretKeyRef:
-      #         name: ades-secret
-      #         key: workflowExecutor.inputs.STAGEOUT_AWS_ACCESS_KEY_ID
-      # - op: add
-      #   path: /spec/template/spec/containers/0/env/-
-      #   value:
-      #     name: STAGEOUT_AWS_SECRET_ACCESS_KEY
-      #     valueFrom:
-      #       secretKeyRef:
-      #         name: ades-secret
-      #         key: workflowExecutor.inputs.STAGEOUT_AWS_SECRET_ACCESS_KEY
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: STAGEOUT_AWS_ACCESS_KEY_ID
+          valueFrom:
+            configMapKeyRef:
+              name: zoo-project-dru-zoofpm-config
+              key: STAGEOUT_AWS_ACCESS_KEY_ID
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: STAGEOUT_AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            configMapKeyRef:
+              name: zoo-project-dru-zoofpm-config
+              key: STAGEOUT_AWS_SECRET_ACCESS_KEY
   - path: delete-pvc-patch.yaml

--- a/apps/ades/envs/dev/kustomization.yaml
+++ b/apps/ades/envs/dev/kustomization.yaml
@@ -21,7 +21,6 @@ configMapGenerator:
       - STAGEOUT_AWS_SERVICEURL=https://s3.eu-west-2.amazonaws.com
       - STAGEOUT_AWS_REGION=eu-west-2
       - STAGEOUT_OUTPUT=eodhp-ades
-      - AWS_ROLE_NAME=ADES-eodhp-dev-9ylvhv4X
 
 patches:
   - target:
@@ -63,14 +62,6 @@ patches:
             configMapKeyRef:
               name: zoo-project-dru-zoofpm-config
               key: STAGEOUT_OUTPUT
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: AWS_ROLE_NAME
-          valueFrom:
-            configMapKeyRef:
-              name: zoo-project-dru-zoofpm-config
-              key: AWS_ROLE_NAME
       # - op: add
       #   path: /spec/template/spec/containers/0/env/-
       #   value:

--- a/apps/ades/envs/dev/kustomization.yaml
+++ b/apps/ades/envs/dev/kustomization.yaml
@@ -21,6 +21,7 @@ configMapGenerator:
       - STAGEOUT_AWS_SERVICEURL=https://s3.eu-west-2.amazonaws.com
       - STAGEOUT_AWS_REGION=eu-west-2
       - STAGEOUT_OUTPUT=eodhp-ades
+      - AWS_ROLE_NAME=ADES-eodhp-dev-9ylvhv4X
 
 patches:
   - target:
@@ -62,6 +63,14 @@ patches:
             configMapKeyRef:
               name: zoo-project-dru-zoofpm-config
               key: STAGEOUT_OUTPUT
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: AWS_ROLE_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: zoo-project-dru-zoofpm-config
+              key: AWS_ROLE_NAME
       # - op: add
       #   path: /spec/template/spec/containers/0/env/-
       #   value:

--- a/apps/ades/envs/dev/kustomization.yaml
+++ b/apps/ades/envs/dev/kustomization.yaml
@@ -21,8 +21,8 @@ configMapGenerator:
       - STAGEOUT_AWS_SERVICEURL=https://s3.eu-west-2.amazonaws.com
       - STAGEOUT_AWS_REGION=eu-west-2
       - STAGEOUT_OUTPUT=eodhp-ades-dev
-      #- STAGEOUT_AWS_ACCESS_KEY_ID=""
-      #- STAGEOUT_AWS_SECRET_ACCESS_KEY=""
+      - STAGEOUT_AWS_ACCESS_KEY_ID=""
+      - STAGEOUT_AWS_SECRET_ACCESS_KEY=""
 
 patches:
   - target:
@@ -64,6 +64,22 @@ patches:
             configMapKeyRef:
               name: zoo-project-dru-zoofpm-config
               key: STAGEOUT_OUTPUT
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: STAGEOUT_AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            configMapKeyRef:
+              name: zoo-project-dru-zoofpm-config
+              key: STAGEOUT_AWS_SECRET_ACCESS_KEY
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: STAGEOUT_AWS_ACCESS_KEY_ID
+          valueFrom:
+            configMapKeyRef:
+              name: zoo-project-dru-zoofpm-config
+              key: STAGEOUT_AWS_ACCESS_KEY_ID
       # - op: add
       #   path: /spec/template/spec/containers/0/env/-
       #   value:

--- a/apps/ades/envs/dev/kustomization.yaml
+++ b/apps/ades/envs/dev/kustomization.yaml
@@ -21,8 +21,8 @@ configMapGenerator:
       - STAGEOUT_AWS_SERVICEURL=https://s3.eu-west-2.amazonaws.com
       - STAGEOUT_AWS_REGION=eu-west-2
       - STAGEOUT_OUTPUT=eodhp-ades-dev
-      - STAGEOUT_AWS_ACCESS_KEY_ID=""
-      - STAGEOUT_AWS_SECRET_ACCESS_KEY=""
+      #- STAGEOUT_AWS_ACCESS_KEY_ID=""
+      #- STAGEOUT_AWS_SECRET_ACCESS_KEY=""
 
 patches:
   - target:
@@ -69,17 +69,17 @@ patches:
         value:
           name: STAGEOUT_AWS_ACCESS_KEY_ID
           valueFrom:
-            configMapKeyRef:
-              name: zoo-project-dru-zoofpm-config
-              key: STAGEOUT_AWS_ACCESS_KEY_ID
+            secretKeyRef:
+              name: ades-secret
+              key: workflowExecutor.inputs.STAGEOUT_AWS_ACCESS_KEY_ID
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
           name: STAGEOUT_AWS_SECRET_ACCESS_KEY
           valueFrom:
-            configMapKeyRef:
-              name: zoo-project-dru-zoofpm-config
-              key: STAGEOUT_AWS_SECRET_ACCESS_KEY
+            secretKeyRef:
+              name: ades-secret
+              key: workflowExecutor.inputs.STAGEOUT_AWS_SECRET_ACCESS_KEY
       - op: add
         path: /spec/template/spec/serviceAccountName
         value: zoo-project-dru

--- a/apps/ades/envs/dev/kustomization.yaml
+++ b/apps/ades/envs/dev/kustomization.yaml
@@ -80,4 +80,10 @@ patches:
             configMapKeyRef:
               name: zoo-project-dru-zoofpm-config
               key: STAGEOUT_AWS_SECRET_ACCESS_KEY
+      - op: add
+        path: /spec/template/spec/serviceAccountName
+        value: zoo-project-dru
+      # - op: add
+      #   path: /spec/template/spec/automountServiceAccountToken
+      #   value: true
   - path: delete-pvc-patch.yaml

--- a/apps/ades/envs/dev/kustomization.yaml
+++ b/apps/ades/envs/dev/kustomization.yaml
@@ -64,22 +64,22 @@ patches:
             configMapKeyRef:
               name: zoo-project-dru-zoofpm-config
               key: STAGEOUT_OUTPUT
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: STAGEOUT_AWS_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              name: ades-secret
-              key: workflowExecutor.inputs.STAGEOUT_AWS_ACCESS_KEY_ID
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: STAGEOUT_AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              name: ades-secret
-              key: workflowExecutor.inputs.STAGEOUT_AWS_SECRET_ACCESS_KEY
+      # - op: add
+      #   path: /spec/template/spec/containers/0/env/-
+      #   value:
+      #     name: STAGEOUT_AWS_ACCESS_KEY_ID
+      #     valueFrom:
+      #       secretKeyRef:
+      #         name: ades-secret
+      #         key: workflowExecutor.inputs.STAGEOUT_AWS_ACCESS_KEY_ID
+      # - op: add
+      #   path: /spec/template/spec/containers/0/env/-
+      #   value:
+      #     name: STAGEOUT_AWS_SECRET_ACCESS_KEY
+      #     valueFrom:
+      #       secretKeyRef:
+      #         name: ades-secret
+      #         key: workflowExecutor.inputs.STAGEOUT_AWS_SECRET_ACCESS_KEY
       - op: add
         path: /spec/template/spec/serviceAccountName
         value: zoo-project-dru
@@ -91,7 +91,7 @@ patches:
       - op: add
         path: /automountServiceAccountToken
         value: true
-  #     - op: add
-  #       path: /metadata/name
-  #       value: ades
+      - op: add
+        path: /metadata/name
+        value: default
   - path: delete-pvc-patch.yaml

--- a/apps/ades/envs/dev/kustomization.yaml
+++ b/apps/ades/envs/dev/kustomization.yaml
@@ -90,8 +90,8 @@ patches:
       # Configure service account manually
       - op: add
         path: /automountServiceAccountToken
-        value: false
-      - op: add
-        path: /metadata/name
-        value: ades
+        value: true
+  #     - op: add
+  #       path: /metadata/name
+  #       value: ades
   - path: delete-pvc-patch.yaml

--- a/apps/ades/envs/dev/kustomization.yaml
+++ b/apps/ades/envs/dev/kustomization.yaml
@@ -20,7 +20,7 @@ configMapGenerator:
     literals:
       - STAGEOUT_AWS_SERVICEURL=https://s3.eu-west-2.amazonaws.com
       - STAGEOUT_AWS_REGION=eu-west-2
-      - STAGEOUT_OUTPUT=eodhp-ades
+      - STAGEOUT_OUTPUT=eodhp-ades-dev
       - STAGEOUT_AWS_ACCESS_KEY_ID=""
       - STAGEOUT_AWS_SECRET_ACCESS_KEY=""
 

--- a/apps/ades/envs/dev/kustomization.yaml
+++ b/apps/ades/envs/dev/kustomization.yaml
@@ -21,8 +21,8 @@ configMapGenerator:
       - STAGEOUT_AWS_SERVICEURL=https://s3.eu-west-2.amazonaws.com
       - STAGEOUT_AWS_REGION=eu-west-2
       - STAGEOUT_OUTPUT=eodhp-ades
-      # - STAGEOUT_AWS_ACCESS_KEY_ID=""
-      # - STAGEOUT_AWS_SECRET_ACCESS_KEY=""
+      - STAGEOUT_AWS_ACCESS_KEY_ID=""
+      - STAGEOUT_AWS_SECRET_ACCESS_KEY=""
 
 patches:
   - target:
@@ -64,20 +64,20 @@ patches:
             configMapKeyRef:
               name: zoo-project-dru-zoofpm-config
               key: STAGEOUT_OUTPUT
-      # - op: add
-      #   path: /spec/template/spec/containers/0/env/-
-      #   value:
-      #     name: STAGEOUT_AWS_ACCESS_KEY_ID
-      #     valueFrom:
-      #       configMapKeyRef:
-      #         name: zoo-project-dru-zoofpm-config
-      #         key: STAGEOUT_AWS_ACCESS_KEY_ID
-      # - op: add
-      #   path: /spec/template/spec/containers/0/env/-
-      #   value:
-      #     name: STAGEOUT_AWS_SECRET_ACCESS_KEY
-      #     valueFrom:
-      #       configMapKeyRef:
-      #         name: zoo-project-dru-zoofpm-config
-      #         key: STAGEOUT_AWS_SECRET_ACCESS_KEY
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: STAGEOUT_AWS_ACCESS_KEY_ID
+          valueFrom:
+            configMapKeyRef:
+              name: zoo-project-dru-zoofpm-config
+              key: STAGEOUT_AWS_ACCESS_KEY_ID
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: STAGEOUT_AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            configMapKeyRef:
+              name: zoo-project-dru-zoofpm-config
+              key: STAGEOUT_AWS_SECRET_ACCESS_KEY
   - path: delete-pvc-patch.yaml

--- a/apps/ades/envs/dev/kustomization.yaml
+++ b/apps/ades/envs/dev/kustomization.yaml
@@ -21,8 +21,6 @@ configMapGenerator:
       - STAGEOUT_AWS_SERVICEURL=https://s3.eu-west-2.amazonaws.com
       - STAGEOUT_AWS_REGION=eu-west-2
       - STAGEOUT_OUTPUT=eodhp-ades-dev
-      #- STAGEOUT_AWS_ACCESS_KEY_ID=""
-      #- STAGEOUT_AWS_SECRET_ACCESS_KEY=""
 
 patches:
   - target:
@@ -64,50 +62,4 @@ patches:
             configMapKeyRef:
               name: zoo-project-dru-zoofpm-config
               key: STAGEOUT_OUTPUT
-      # - op: add
-      #   path: /spec/template/spec/containers/0/env/-
-      #   value:
-      #     name: STAGEOUT_AWS_SECRET_ACCESS_KEY
-      #     valueFrom:
-      #       configMapKeyRef:
-      #         name: zoo-project-dru-zoofpm-config
-      #         key: STAGEOUT_AWS_SECRET_ACCESS_KEY
-      # - op: add
-      #   path: /spec/template/spec/containers/0/env/-
-      #   value:
-      #     name: STAGEOUT_AWS_ACCESS_KEY_ID
-      #     valueFrom:
-      #       configMapKeyRef:
-      #         name: zoo-project-dru-zoofpm-config
-      #         key: STAGEOUT_AWS_ACCESS_KEY_ID
-      # - op: add
-      #   path: /spec/template/spec/containers/0/env/-
-      #   value:
-      #     name: STAGEOUT_AWS_ACCESS_KEY_ID
-      #     valueFrom:
-      #       secretKeyRef:
-      #         name: ades-secret
-      #         key: workflowExecutor.inputs.STAGEOUT_AWS_ACCESS_KEY_ID
-      # - op: add
-      #   path: /spec/template/spec/containers/0/env/-
-      #   value:
-      #     name: STAGEOUT_AWS_SECRET_ACCESS_KEY
-      #     valueFrom:
-      #       secretKeyRef:
-      #         name: ades-secret
-      #         key: workflowExecutor.inputs.STAGEOUT_AWS_SECRET_ACCESS_KEY
-      - op: add
-        path: /spec/template/spec/serviceAccountName
-        value: zoo-project-dru
-  - target:
-      kind: ServiceAccount
-      name: zoo-project-dru
-    patch: |-
-      # Configure service account manually
-      - op: add
-        path: /automountServiceAccountToken
-        value: true
-      - op: add
-        path: /metadata/name
-        value: default
   - path: delete-pvc-patch.yaml

--- a/apps/ades/envs/dev/kustomization.yaml
+++ b/apps/ades/envs/dev/kustomization.yaml
@@ -83,7 +83,15 @@ patches:
       - op: add
         path: /spec/template/spec/serviceAccountName
         value: zoo-project-dru
-      # - op: add
-      #   path: /spec/template/spec/automountServiceAccountToken
-      #   value: true
+  - target:
+      kind: ServiceAccount
+      name: zoo-project-dru
+    patch: |-
+      # Configure service account manually
+      - op: add
+        path: /automountServiceAccountToken
+        value: false
+      - op: add
+        path: /metadata/name
+        value: ades
   - path: delete-pvc-patch.yaml

--- a/apps/ades/envs/dev/kustomization.yaml
+++ b/apps/ades/envs/dev/kustomization.yaml
@@ -21,8 +21,8 @@ configMapGenerator:
       - STAGEOUT_AWS_SERVICEURL=https://s3.eu-west-2.amazonaws.com
       - STAGEOUT_AWS_REGION=eu-west-2
       - STAGEOUT_OUTPUT=eodhp-ades
-      - STAGEOUT_AWS_ACCESS_KEY_ID=""
-      - STAGEOUT_AWS_SECRET_ACCESS_KEY=""
+      # - STAGEOUT_AWS_ACCESS_KEY_ID=""
+      # - STAGEOUT_AWS_SECRET_ACCESS_KEY=""
 
 patches:
   - target:
@@ -64,20 +64,20 @@ patches:
             configMapKeyRef:
               name: zoo-project-dru-zoofpm-config
               key: STAGEOUT_OUTPUT
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: STAGEOUT_AWS_ACCESS_KEY_ID
-          valueFrom:
-            configMapKeyRef:
-              name: zoo-project-dru-zoofpm-config
-              key: STAGEOUT_AWS_ACCESS_KEY_ID
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: STAGEOUT_AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            configMapKeyRef:
-              name: zoo-project-dru-zoofpm-config
-              key: STAGEOUT_AWS_SECRET_ACCESS_KEY
+      # - op: add
+      #   path: /spec/template/spec/containers/0/env/-
+      #   value:
+      #     name: STAGEOUT_AWS_ACCESS_KEY_ID
+      #     valueFrom:
+      #       configMapKeyRef:
+      #         name: zoo-project-dru-zoofpm-config
+      #         key: STAGEOUT_AWS_ACCESS_KEY_ID
+      # - op: add
+      #   path: /spec/template/spec/containers/0/env/-
+      #   value:
+      #     name: STAGEOUT_AWS_SECRET_ACCESS_KEY
+      #     valueFrom:
+      #       configMapKeyRef:
+      #         name: zoo-project-dru-zoofpm-config
+      #         key: STAGEOUT_AWS_SECRET_ACCESS_KEY
   - path: delete-pvc-patch.yaml

--- a/apps/ades/envs/dev/kustomization.yaml
+++ b/apps/ades/envs/dev/kustomization.yaml
@@ -37,7 +37,7 @@ patches:
       kind: Deployment
       name: zoo-project-dru-zoofpm
     patch: |-
-      # Add STAGEOUT secrets as environment variables
+      # Add STAGEOUT values as environment variables
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:

--- a/apps/ades/envs/dev/kustomization.yaml
+++ b/apps/ades/envs/dev/kustomization.yaml
@@ -21,8 +21,8 @@ configMapGenerator:
       - STAGEOUT_AWS_SERVICEURL=https://s3.eu-west-2.amazonaws.com
       - STAGEOUT_AWS_REGION=eu-west-2
       - STAGEOUT_OUTPUT=eodhp-ades-dev
-      - STAGEOUT_AWS_ACCESS_KEY_ID=""
-      - STAGEOUT_AWS_SECRET_ACCESS_KEY=""
+      #- STAGEOUT_AWS_ACCESS_KEY_ID=""
+      #- STAGEOUT_AWS_SECRET_ACCESS_KEY=""
 
 patches:
   - target:
@@ -64,38 +64,38 @@ patches:
             configMapKeyRef:
               name: zoo-project-dru-zoofpm-config
               key: STAGEOUT_OUTPUT
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: STAGEOUT_AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            configMapKeyRef:
-              name: zoo-project-dru-zoofpm-config
-              key: STAGEOUT_AWS_SECRET_ACCESS_KEY
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: STAGEOUT_AWS_ACCESS_KEY_ID
-          valueFrom:
-            configMapKeyRef:
-              name: zoo-project-dru-zoofpm-config
-              key: STAGEOUT_AWS_ACCESS_KEY_ID
-      # - op: add
-      #   path: /spec/template/spec/containers/0/env/-
-      #   value:
-      #     name: STAGEOUT_AWS_ACCESS_KEY_ID
-      #     valueFrom:
-      #       secretKeyRef:
-      #         name: ades-secret
-      #         key: workflowExecutor.inputs.STAGEOUT_AWS_ACCESS_KEY_ID
       # - op: add
       #   path: /spec/template/spec/containers/0/env/-
       #   value:
       #     name: STAGEOUT_AWS_SECRET_ACCESS_KEY
       #     valueFrom:
-      #       secretKeyRef:
-      #         name: ades-secret
-      #         key: workflowExecutor.inputs.STAGEOUT_AWS_SECRET_ACCESS_KEY
+      #       configMapKeyRef:
+      #         name: zoo-project-dru-zoofpm-config
+      #         key: STAGEOUT_AWS_SECRET_ACCESS_KEY
+      # - op: add
+      #   path: /spec/template/spec/containers/0/env/-
+      #   value:
+      #     name: STAGEOUT_AWS_ACCESS_KEY_ID
+      #     valueFrom:
+      #       configMapKeyRef:
+      #         name: zoo-project-dru-zoofpm-config
+      #         key: STAGEOUT_AWS_ACCESS_KEY_ID
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: STAGEOUT_AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: ades-secret
+              key: workflowExecutor.inputs.STAGEOUT_AWS_ACCESS_KEY_ID
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: STAGEOUT_AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: ades-secret
+              key: workflowExecutor.inputs.STAGEOUT_AWS_SECRET_ACCESS_KEY
       - op: add
         path: /spec/template/spec/serviceAccountName
         value: zoo-project-dru

--- a/apps/ades/envs/dev/secrets.yaml
+++ b/apps/ades/envs/dev/secrets.yaml
@@ -1,27 +1,6 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: ades
-spec:
-  refreshInterval: 1m
-  secretStoreRef:
-    name: secret-store
-    kind: ClusterSecretStore
-  target:
-    name: ades-secret
-  data:
-    - secretKey: workflowExecutor.inputs.STAGEOUT_AWS_ACCESS_KEY_ID
-      remoteRef:
-        key: eodhp-dev
-        property: "ades.workflowExecutor.inputs.STAGEOUT_AWS_ACCESS_KEY_ID"
-    - secretKey: workflowExecutor.inputs.STAGEOUT_AWS_SECRET_ACCESS_KEY
-      remoteRef:
-        key: eodhp-dev
-        property: "ades.workflowExecutor.inputs.STAGEOUT_AWS_SECRET_ACCESS_KEY"
----
-apiVersion: external-secrets.io/v1beta1
-kind: ExternalSecret
-metadata:
   name: basic-auth
   namespace: ades
 spec:

--- a/apps/ades/envs/dev/values.yaml
+++ b/apps/ades/envs/dev/values.yaml
@@ -95,12 +95,14 @@ files:
                 print(f"subfolder: {subfolder}", file=sys.stderr)
                 print(f"collection_id: {collection_id}", file=sys.stderr)
                 
-                aws_access_key_id = os.environ["AWS_ACCESS_KEY_ID"]
-                aws_secret_access_key = os.environ["AWS_SECRET_ACCESS_KEY"]
+                #aws_access_key_id = os.environ["AWS_ACCESS_KEY_ID"]
+                #aws_secret_access_key = os.environ["AWS_SECRET_ACCESS_KEY"]
+                role_name = os.environ["AWS_ROLE_NAME"]
+                print(f"role_name: {role_name}", file=sys.stderr)
                 region_name = os.environ["AWS_REGION"]
                 endpoint_url = os.environ["AWS_S3_ENDPOINT"]
-                print(f"aws_access_key_id: {aws_access_key_id}", file=sys.stderr)
-                print(f"aws_secret_access_key: {aws_secret_access_key}", file=sys.stderr)
+                #print(f"aws_access_key_id: {aws_access_key_id}", file=sys.stderr)
+                #print(f"aws_secret_access_key: {aws_secret_access_key}", file=sys.stderr)
                 print(f"region_name: {region_name}", file=sys.stderr)
                 print(f"endpoint_url: {endpoint_url}", file=sys.stderr)
                 
@@ -111,12 +113,18 @@ files:
                     """Custom STAC IO class that uses boto3 to read from S3."""
                 
                     def __init__(self):
+                        sts_client = boto3.client("sts")
+                        assumed_role_object=sts_client.assume_role(
+                        RoleArn=f"arn:aws:iam::account-of-role-to-assume:role/{role_name}",
+                        RoleSessionName="AssumeRoleSession1"
+                        )
+                        credentials=assumed_role_object['Credentials']
                         self.session = botocore.session.Session()
                         self.s3_client = self.session.create_client(
                             service_name="s3",
                             use_ssl=True,
-                            aws_access_key_id=aws_access_key_id,
-                            aws_secret_access_key=aws_secret_access_key,
+                            aws_access_key_id=credentials["AccessKeyId"],
+                            aws_secret_access_key=credentials["SecretAccessKey"],
                             endpoint_url=endpoint_url,
                             region_name=region_name,
                         )
@@ -133,11 +141,16 @@ files:
                         else:
                             super().write_text(dest, txt, *args, **kwargs)
                 
-                
+                sts_client = boto3.client("sts")
+                assumed_role_object=sts_client.assume_role(
+                  RoleArn=f"arn:aws:iam::account-of-role-to-assume:role/{role_name}",
+                  RoleSessionName="AssumeRoleSession1"
+                )
+                credentials=assumed_role_object['Credentials']
                 client = boto3.client(
                     "s3",
-                    aws_access_key_id=aws_access_key_id,
-                    aws_secret_access_key=aws_secret_access_key,
+                    aws_access_key_id=credentials["AccessKeyId"],
+                    aws_secret_access_key=credentials["SecretAccessKey"],
                     endpoint_url=endpoint_url,
                     region_name=region_name,
                 )

--- a/apps/ades/envs/dev/values.yaml
+++ b/apps/ades/envs/dev/values.yaml
@@ -112,7 +112,7 @@ files:
                 
                     def __init__(self):
                         self.session = botocore.session.Session()
-                        if aws_access_key_id and aws_secret_access_key:
+                        if False:
                             self.s3_client = self.session.create_client(
                               service_name="s3",
                               use_ssl=True,
@@ -135,7 +135,7 @@ files:
                             )
                         else:
                             super().write_text(dest, txt, *args, **kwargs)
-                if aws_access_key_id and aws_secret_access_key:
+                if False:
                     client = boto3.client(
                         "s3",
                         aws_access_key_id=aws_access_key_id,
@@ -222,8 +222,8 @@ workflow:
     STAGEIN_AWS_ACCESS_KEY_ID: test
     STAGEIN_AWS_SECRET_ACCESS_KEY: test
     STAGEIN_AWS_REGION: RegionOne
-    STAGEOUT_AWS_ACCESS_KEY_ID: ""
-    STAGEOUT_AWS_SECRET_ACCESS_KEY: ""
+    #STAGEOUT_AWS_ACCESS_KEY_ID: ""
+    #STAGEOUT_AWS_SECRET_ACCESS_KEY: ""
   nodeSelector:
     minikube.k8s.io/primary: "true"
   storageClass: file-storage

--- a/apps/ades/envs/dev/values.yaml
+++ b/apps/ades/envs/dev/values.yaml
@@ -239,14 +239,14 @@ ingress:
     nginx.ingress.kubernetes.io/auth-secret: basic-auth
     nginx.ingress.kubernetes.io/auth-realm: "Authentication Required"
   hosts:
-    - host: dev.eodhp.eco-ke-staging.com
+    - host: ades.dev.eodhp.eco-ke-staging.com
       paths:
         - path: /
           pathType: ImplementationSpecific
   tls:
     - hosts:
-        - dev.eodhp.eco-ke-staging.com
-      secretName: dev.eodhp.eco-ke-staging.com-tls
+        - ades.dev.eodhp.eco-ke-staging.com
+      secretName: ades.dev.eodhp.eco-ke-staging.com-tls
 persistence:
   procServicesStorageClass: file-storage
   storageClass: file-storage

--- a/apps/ades/envs/dev/values.yaml
+++ b/apps/ades/envs/dev/values.yaml
@@ -12,6 +12,16 @@ customConfig:
     eoepca: |-
       domain=192-168-67-2.nip.io
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: |
+    eks.amazonaws.com/role-arn: "arn:aws:iam::312280911266:role/ades"
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  # name: "ades"
+
 files:
   # Directory 'files/cwlwrapper-assets' - assets for ConfigMap 'XXX-cwlwrapper-config'
   cwlwrapperAssets:

--- a/apps/ades/envs/dev/values.yaml
+++ b/apps/ades/envs/dev/values.yaml
@@ -20,7 +20,7 @@ serviceAccount:
     eks.amazonaws.com/role-arn: "arn:aws:iam::312280911266:role/ADES-eodhp-dev-9ylvhv4X"
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  name: "ades"
+  #name: "ades"
 
 files:
   # Directory 'files/cwlwrapper-assets' - assets for ConfigMap 'XXX-cwlwrapper-config'
@@ -95,8 +95,8 @@ files:
                 print(f"subfolder: {subfolder}", file=sys.stderr)
                 print(f"collection_id: {collection_id}", file=sys.stderr)
                 
-                #aws_access_key_id = os.environ["AWS_ACCESS_KEY_ID"]
-                #aws_secret_access_key = os.environ["AWS_SECRET_ACCESS_KEY"]
+                aws_access_key_id = os.environ["AWS_ACCESS_KEY_ID"]
+                aws_secret_access_key = os.environ["AWS_SECRET_ACCESS_KEY"]
                 role_name = os.environ["AWS_ROLE_NAME"]
                 print(f"role_name: {role_name}", file=sys.stderr)
                 region_name = os.environ["AWS_REGION"]
@@ -113,18 +113,12 @@ files:
                     """Custom STAC IO class that uses boto3 to read from S3."""
                 
                     def __init__(self):
-                        sts_client = boto3.client("sts")
-                        assumed_role_object=sts_client.assume_role(
-                        RoleArn=f"arn:aws:iam::account-of-role-to-assume:role/{role_name}",
-                        RoleSessionName="AssumeRoleSession1"
-                        )
-                        credentials=assumed_role_object['Credentials']
                         self.session = botocore.session.Session()
                         self.s3_client = self.session.create_client(
                             service_name="s3",
                             use_ssl=True,
-                            aws_access_key_id=credentials["AccessKeyId"],
-                            aws_secret_access_key=credentials["SecretAccessKey"],
+                            aws_access_key_id=aws_access_key_id,
+                            aws_secret_access_key=aws_secret_access_key,
                             endpoint_url=endpoint_url,
                             region_name=region_name,
                         )
@@ -141,16 +135,10 @@ files:
                         else:
                             super().write_text(dest, txt, *args, **kwargs)
                 
-                sts_client = boto3.client("sts")
-                assumed_role_object=sts_client.assume_role(
-                  RoleArn=f"arn:aws:iam::account-of-role-to-assume:role/{role_name}",
-                  RoleSessionName="AssumeRoleSession1"
-                )
-                credentials=assumed_role_object['Credentials']
                 client = boto3.client(
                     "s3",
-                    aws_access_key_id=credentials["AccessKeyId"],
-                    aws_secret_access_key=credentials["SecretAccessKey"],
+                    aws_access_key_id=aws_access_key_id,
+                    aws_secret_access_key=aws_secret_access_key,
                     endpoint_url=endpoint_url,
                     region_name=region_name,
                 )

--- a/apps/ades/envs/dev/values.yaml
+++ b/apps/ades/envs/dev/values.yaml
@@ -123,7 +123,6 @@ files:
                               region_name=region_name,
                             )
                         else:
-                            print("using normal client - in class")
                             self.s3_client = self.session.create_client("s3")
                 
                     def write_text(self, dest, txt, *args, **kwargs):
@@ -146,7 +145,6 @@ files:
                         region_name=region_name,
                     )
                 else:
-                    print("using normal client")
                     client = boto3.client("s3")
                 
                 StacIO.set_default(CustomStacIO)

--- a/apps/ades/envs/dev/values.yaml
+++ b/apps/ades/envs/dev/values.yaml
@@ -174,7 +174,6 @@ files:
                             os.path.join(subfolder, collection_id, item.id, os.path.basename(asset.href))
                         )
                         print(f"upload {asset.href} to s3://{bucket}/{s3_path}",file=sys.stderr)
-                        print("s3_path " + s3_path)
                         client.upload_file(
                             asset.get_absolute_href(),
                             bucket,

--- a/apps/ades/envs/dev/values.yaml
+++ b/apps/ades/envs/dev/values.yaml
@@ -18,6 +18,7 @@ serviceAccount:
   # Annotations to add to the service account
   annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::312280911266:role/ADES-eodhp-dev-v3KdP0Ie"
+  #automountServiceAccountToken: false
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   #name: "ades"
@@ -186,6 +187,7 @@ files:
                             os.path.join(subfolder, collection_id, item.id, os.path.basename(asset.href))
                         )
                         print(f"upload {asset.href} to s3://{bucket}/{s3_path}",file=sys.stderr)
+                        print("s3_path " + s3_path)
                         client.upload_file(
                             asset.get_absolute_href(),
                             bucket,

--- a/apps/ades/envs/dev/values.yaml
+++ b/apps/ades/envs/dev/values.yaml
@@ -239,14 +239,14 @@ ingress:
     nginx.ingress.kubernetes.io/auth-secret: basic-auth
     nginx.ingress.kubernetes.io/auth-realm: "Authentication Required"
   hosts:
-    - host: ades.dev.eodatahub.org.uk
+    - host: dev.eodhp.eco-ke-staging.com
       paths:
         - path: /
           pathType: ImplementationSpecific
   tls:
     - hosts:
-        - ades.dev.eodatahub.org.uk
-      secretName: ades.dev.eodatahub.org.uk-tls
+        - dev.eodhp.eco-ke-staging.com
+      secretName: dev.eodhp.eco-ke-staging.com-tls
 persistence:
   procServicesStorageClass: file-storage
   storageClass: file-storage

--- a/apps/ades/envs/dev/values.yaml
+++ b/apps/ades/envs/dev/values.yaml
@@ -21,7 +21,7 @@ serviceAccount:
   #automountServiceAccountToken: false
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  #name: "ades"
+  name: "ades"
 
 files:
   # Directory 'files/cwlwrapper-assets' - assets for ConfigMap 'XXX-cwlwrapper-config'

--- a/apps/ades/envs/dev/values.yaml
+++ b/apps/ades/envs/dev/values.yaml
@@ -243,14 +243,14 @@ ingress:
     nginx.ingress.kubernetes.io/auth-secret: basic-auth
     nginx.ingress.kubernetes.io/auth-realm: "Authentication Required"
   hosts:
-    - host: ades.dev.eodhp.eco-ke-staging.com
+    - host: ades.dev.eodatahub.org.uk
       paths:
         - path: /
           pathType: ImplementationSpecific
   tls:
     - hosts:
-        - ades.dev.eodhp.eco-ke-staging.com
-      secretName: ades.dev.eodhp.eco-ke-staging.com-tls
+        - ades.dev.eodatahub.org.uk
+      secretName: ades.dev.eodatahub.org.uk-tls
 persistence:
   procServicesStorageClass: file-storage
   storageClass: file-storage

--- a/apps/ades/envs/dev/values.yaml
+++ b/apps/ades/envs/dev/values.yaml
@@ -17,10 +17,10 @@ serviceAccount:
   create: true
   # Annotations to add to the service account
   annotations:
-    eks.amazonaws.com/role-arn: "arn:aws:iam::312280911266:role/ades"
+    eks.amazonaws.com/role-arn: "arn:aws:iam::312280911266:role/ADES-eodhp-dev-9ylvhv4X"
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  # name: "ades"
+  # name: ""
 
 files:
   # Directory 'files/cwlwrapper-assets' - assets for ConfigMap 'XXX-cwlwrapper-config'

--- a/apps/ades/envs/dev/values.yaml
+++ b/apps/ades/envs/dev/values.yaml
@@ -16,7 +16,7 @@ serviceAccount:
   # Specifies whether a service account should be created
   create: true
   # Annotations to add to the service account
-  annotations: |
+  annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::312280911266:role/ades"
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template

--- a/apps/ades/envs/dev/values.yaml
+++ b/apps/ades/envs/dev/values.yaml
@@ -17,7 +17,7 @@ serviceAccount:
   create: true
   # Annotations to add to the service account
   annotations:
-    eks.amazonaws.com/role-arn: "arn:aws:iam::312280911266:role/ADES-eodhp-dev-9ylvhv4X"
+    eks.amazonaws.com/role-arn: "arn:aws:iam::312280911266:role/ADES-eodhp-dev-v3KdP0Ie"
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   #name: "ades"

--- a/apps/ades/envs/dev/values.yaml
+++ b/apps/ades/envs/dev/values.yaml
@@ -94,7 +94,7 @@ files:
                 print(f"bucket: {bucket}", file=sys.stderr)
                 print(f"subfolder: {subfolder}", file=sys.stderr)
                 print(f"collection_id: {collection_id}", file=sys.stderr)
-                if os.getenv("AWS_ACCESS_KEY") and os.getenv("AWS_SECRET_ACCESS_KEY"):
+                if os.environ["AWS_ACCESS_KEY_ID"] and os.environ["AWS_SECRET_ACCESS_KEY"]:
                     aws_access_key_id = os.environ["AWS_ACCESS_KEY_ID"]
                     aws_secret_access_key = os.environ["AWS_SECRET_ACCESS_KEY"]
                     print(f"aws_access_key_id: {aws_access_key_id}", file=sys.stderr)

--- a/apps/ades/envs/dev/values.yaml
+++ b/apps/ades/envs/dev/values.yaml
@@ -12,17 +12,6 @@ customConfig:
     eoepca: |-
       domain=192-168-67-2.nip.io
 
-serviceAccount:
-  # Specifies whether a service account should be created
-  create: true
-  # Annotations to add to the service account
-  annotations:
-    eks.amazonaws.com/role-arn: "arn:aws:iam::312280911266:role/ADES-eodhp-dev-v3KdP0Ie"
-  #automountServiceAccountToken: false
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
-  name: "ades"
-
 files:
   # Directory 'files/cwlwrapper-assets' - assets for ConfigMap 'XXX-cwlwrapper-config'
   cwlwrapperAssets:

--- a/apps/ades/envs/dev/values.yaml
+++ b/apps/ades/envs/dev/values.yaml
@@ -17,10 +17,10 @@ serviceAccount:
   create: true
   # Annotations to add to the service account
   annotations:
-    eks.amazonaws.com/role-arn: "arn:aws:iam::312280911266:role/ADES-eodhp-dev-9ylvhv4X"
+    eks.amazonaws.com/role-arn: "arn:aws:iam:::role/ADES-eodhp-dev-9ylvhv4X"
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  # name: ""
+  name: "ades"
 
 files:
   # Directory 'files/cwlwrapper-assets' - assets for ConfigMap 'XXX-cwlwrapper-config'

--- a/apps/ades/envs/dev/values.yaml
+++ b/apps/ades/envs/dev/values.yaml
@@ -222,6 +222,8 @@ workflow:
     STAGEIN_AWS_ACCESS_KEY_ID: test
     STAGEIN_AWS_SECRET_ACCESS_KEY: test
     STAGEIN_AWS_REGION: RegionOne
+    STAGEOUT_AWS_ACCESS_KEY_ID: ""
+    STAGEOUT_AWS_SECRET_ACCESS_KEY: ""
   nodeSelector:
     minikube.k8s.io/primary: "true"
   storageClass: file-storage

--- a/apps/ades/envs/dev/values.yaml
+++ b/apps/ades/envs/dev/values.yaml
@@ -17,7 +17,7 @@ serviceAccount:
   create: true
   # Annotations to add to the service account
   annotations:
-    eks.amazonaws.com/role-arn: "arn:aws:iam:::role/ADES-eodhp-dev-9ylvhv4X"
+    eks.amazonaws.com/role-arn: "arn:aws:iam::312280911266:role/ADES-eodhp-dev-9ylvhv4X"
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: "ades"

--- a/apps/ades/envs/dev/values.yaml
+++ b/apps/ades/envs/dev/values.yaml
@@ -94,15 +94,13 @@ files:
                 print(f"bucket: {bucket}", file=sys.stderr)
                 print(f"subfolder: {subfolder}", file=sys.stderr)
                 print(f"collection_id: {collection_id}", file=sys.stderr)
-                
-                aws_access_key_id = os.environ["AWS_ACCESS_KEY_ID"]
-                aws_secret_access_key = os.environ["AWS_SECRET_ACCESS_KEY"]
-                role_name = os.environ["AWS_ROLE_NAME"]
-                print(f"role_name: {role_name}", file=sys.stderr)
+                if os.getenv("AWS_ACCESS_KEY") and os.getenv("AWS_SECRET_ACCESS_KEY"):
+                    aws_access_key_id = os.environ["AWS_ACCESS_KEY_ID"]
+                    aws_secret_access_key = os.environ["AWS_SECRET_ACCESS_KEY"]
+                    print(f"aws_access_key_id: {aws_access_key_id}", file=sys.stderr)
+                    print(f"aws_secret_access_key: {aws_secret_access_key}", file=sys.stderr)
                 region_name = os.environ["AWS_REGION"]
                 endpoint_url = os.environ["AWS_S3_ENDPOINT"]
-                #print(f"aws_access_key_id: {aws_access_key_id}", file=sys.stderr)
-                #print(f"aws_secret_access_key: {aws_secret_access_key}", file=sys.stderr)
                 print(f"region_name: {region_name}", file=sys.stderr)
                 print(f"endpoint_url: {endpoint_url}", file=sys.stderr)
                 
@@ -114,14 +112,17 @@ files:
                 
                     def __init__(self):
                         self.session = botocore.session.Session()
-                        self.s3_client = self.session.create_client(
-                            service_name="s3",
-                            use_ssl=True,
-                            aws_access_key_id=aws_access_key_id,
-                            aws_secret_access_key=aws_secret_access_key,
-                            endpoint_url=endpoint_url,
-                            region_name=region_name,
-                        )
+                        if aws_access_key_id and aws_secret_access_key:
+                            self.s3_client = self.session.create_client(
+                              service_name="s3",
+                              use_ssl=True,
+                              aws_access_key_id=aws_access_key_id,
+                              aws_secret_access_key=aws_secret_access_key,
+                              endpoint_url=endpoint_url,
+                              region_name=region_name,
+                            )
+                        else:
+                            self.s3_client = self.session.create_client("s3")
                 
                     def write_text(self, dest, txt, *args, **kwargs):
                         parsed = urlparse(dest)
@@ -134,14 +135,16 @@ files:
                             )
                         else:
                             super().write_text(dest, txt, *args, **kwargs)
-                
-                client = boto3.client(
-                    "s3",
-                    aws_access_key_id=aws_access_key_id,
-                    aws_secret_access_key=aws_secret_access_key,
-                    endpoint_url=endpoint_url,
-                    region_name=region_name,
-                )
+                if aws_access_key_id and aws_secret_access_key:
+                    client = boto3.client(
+                        "s3",
+                        aws_access_key_id=aws_access_key_id,
+                        aws_secret_access_key=aws_secret_access_key,
+                        endpoint_url=endpoint_url,
+                        region_name=region_name,
+                    )
+                else:
+                    client = boto3.client("s3")
                 
                 StacIO.set_default(CustomStacIO)
                 

--- a/apps/ades/envs/dev/values.yaml
+++ b/apps/ades/envs/dev/values.yaml
@@ -122,6 +122,7 @@ files:
                               region_name=region_name,
                             )
                         else:
+                            print("using normal client - in class")
                             self.s3_client = self.session.create_client("s3")
                 
                     def write_text(self, dest, txt, *args, **kwargs):
@@ -144,6 +145,7 @@ files:
                         region_name=region_name,
                     )
                 else:
+                    print("using normal client")
                     client = boto3.client("s3")
                 
                 StacIO.set_default(CustomStacIO)

--- a/apps/ades/envs/dev/values.yaml
+++ b/apps/ades/envs/dev/values.yaml
@@ -226,8 +226,8 @@ workflow:
     STAGEIN_AWS_ACCESS_KEY_ID: test
     STAGEIN_AWS_SECRET_ACCESS_KEY: test
     STAGEIN_AWS_REGION: RegionOne
-    #STAGEOUT_AWS_ACCESS_KEY_ID: ""
-    #STAGEOUT_AWS_SECRET_ACCESS_KEY: ""
+    STAGEOUT_AWS_ACCESS_KEY_ID: ""
+    STAGEOUT_AWS_SECRET_ACCESS_KEY: ""
   nodeSelector:
     minikube.k8s.io/primary: "true"
   storageClass: file-storage

--- a/apps/ades/envs/dev/values.yaml
+++ b/apps/ades/envs/dev/values.yaml
@@ -113,7 +113,7 @@ files:
                 
                     def __init__(self):
                         self.session = botocore.session.Session()
-                        if False:
+                        if os.environ["AWS_ACCESS_KEY_ID"] and os.environ["AWS_SECRET_ACCESS_KEY"]:
                             self.s3_client = self.session.create_client(
                               service_name="s3",
                               use_ssl=True,
@@ -137,7 +137,7 @@ files:
                             )
                         else:
                             super().write_text(dest, txt, *args, **kwargs)
-                if False:
+                if os.environ["AWS_ACCESS_KEY_ID"] and os.environ["AWS_SECRET_ACCESS_KEY"]:
                     client = boto3.client(
                         "s3",
                         aws_access_key_id=aws_access_key_id,


### PR DESCRIPTION
Updated deployment to write outputs to an S3 bucket using service accounts for S3 (write) access. Further updates because of this:
- removing external secrets for access credentials
- updating stageout code to use the service account rather than environment variables.