### PR TITLE
Feature/eodhp 128 allow workflow to take public rc input

### DIFF
--- a/apps/ades/envs/dev/values.yaml
+++ b/apps/ades/envs/dev/values.yaml
@@ -92,19 +92,11 @@ files:
                 bucket = sys.argv[2]
                 subfolder = sys.argv[3]
                 collection_id = sys.argv[4]
-                print(f"cat_url: {cat_url}", file=sys.stderr)
-                print(f"bucket: {bucket}", file=sys.stderr)
-                print(f"subfolder: {subfolder}", file=sys.stderr)
-                print(f"collection_id: {collection_id}", file=sys.stderr)
                 if os.environ["AWS_ACCESS_KEY_ID"] and os.environ["AWS_SECRET_ACCESS_KEY"]:
                     aws_access_key_id = os.environ["AWS_ACCESS_KEY_ID"]
                     aws_secret_access_key = os.environ["AWS_SECRET_ACCESS_KEY"]
-                    print(f"aws_access_key_id: {aws_access_key_id}", file=sys.stderr)
-                    print(f"aws_secret_access_key: {aws_secret_access_key}", file=sys.stderr)
                 region_name = os.environ["AWS_REGION"]
                 endpoint_url = os.environ["AWS_S3_ENDPOINT"]
-                print(f"region_name: {region_name}", file=sys.stderr)
-                print(f"endpoint_url: {endpoint_url}", file=sys.stderr)
                 
                 shutil.copytree(cat_url, "/tmp/catalog")
                 cat = pystac.read_file(os.path.join("/tmp/catalog", "catalog.json"))

--- a/apps/ades/envs/dev/values.yaml
+++ b/apps/ades/envs/dev/values.yaml
@@ -52,12 +52,12 @@ files:
                       ${
                           if( !Array.isArray(inputs.wf_outputs) ) 
                           {
-                              return inputs.wf_outputs.path + "/catalog.json";
+                              return inputs.wf_outputs.path;
                           }
                           var args=[];
                           for (var i = 0; i < inputs.wf_outputs.length; i++) 
                           {
-                              args.push(inputs.wf_outputs[i].path + "/catalog.json");
+                              args.push(inputs.wf_outputs[i].path);
                           }
                           return args;
                       }

--- a/apps/ades/envs/dev/values.yaml
+++ b/apps/ades/envs/dev/values.yaml
@@ -48,7 +48,19 @@ files:
         - python
         - stageout.py
       arguments:
-        - $( inputs.wf_outputs.path )
+        - valueFrom: |
+                      ${
+                          if( !Array.isArray(inputs.wf_outputs) ) 
+                          {
+                              return inputs.wf_outputs.path + "/catalog.json";
+                          }
+                          var args=[];
+                          for (var i = 0; i < inputs.wf_outputs.length; i++) 
+                          {
+                              args.push(inputs.wf_outputs[i].path + "/catalog.json");
+                          }
+                          return args;
+                      }
         - $( inputs.STAGEOUT_OUTPUT )
         - $( inputs.process )
         - $( inputs.collection_id )


### PR DESCRIPTION
Updated deployment to better handle STAC item inputs taken from public resources, e.g. those found in the Resource Catalog. The updates ensure directory outputs from the application package can be handled (e.g. those form the snuggs example app) and will be output correctly to the S3 bucket. 
Also cleaned up the stageout code in the values file to remove unnecessary print statements. 