### PR TITLE
bugfix/EODHP-230-ades-is-not-configured-correctly-for-path-routing

### DIFF
--- a/apps/ades/envs/dev/values.yaml
+++ b/apps/ades/envs/dev/values.yaml
@@ -223,7 +223,6 @@ workflow:
   storageClass: file-storage
 ingress:
   enabled: true
-
   annotations:
     kubernetes.io/ingress.class: nginx
     ingress.kubernetes.io/ssl-redirect: "false"
@@ -232,6 +231,7 @@ ingress:
     nginx.ingress.kubernetes.io/auth-secret: basic-auth
     nginx.ingress.kubernetes.io/auth-realm: "Authentication Required"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
+  hosturl: https://dev.eodatahub.org.uk/ades
   hosts:
     - host: dev.eodatahub.org.uk
       paths:


### PR DESCRIPTION
ADES is now deployed at an ingress path (not at root of subdomain). ADES URLs reported in request responses were not correct (they omitted the path). This update defines the hosturl in the values file so that response URLs are correct.