### PR TITLE
Release to test

### DIFF
--- a/apps/ades/envs/test/kustomization.yaml
+++ b/apps/ades/envs/test/kustomization.yaml
@@ -20,7 +20,7 @@ configMapGenerator:
     literals:
       - STAGEOUT_AWS_SERVICEURL=https://s3.eu-west-2.amazonaws.com
       - STAGEOUT_AWS_REGION=eu-west-2
-      - STAGEOUT_OUTPUT=eodhp-ades
+      - STAGEOUT_OUTPUT=eodhp-ades-test
 
 patches:
   - target:
@@ -37,7 +37,7 @@ patches:
       kind: Deployment
       name: zoo-project-dru-zoofpm
     patch: |-
-      # Add STAGEOUT secrets as environment variables
+      # Add STAGEOUT values as environment variables
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
@@ -62,20 +62,4 @@ patches:
             configMapKeyRef:
               name: zoo-project-dru-zoofpm-config
               key: STAGEOUT_OUTPUT
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: STAGEOUT_AWS_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              name: ades-secret
-              key: workflowExecutor.inputs.STAGEOUT_AWS_ACCESS_KEY_ID
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: STAGEOUT_AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              name: ades-secret
-              key: workflowExecutor.inputs.STAGEOUT_AWS_SECRET_ACCESS_KEY
   - path: delete-pvc-patch.yaml

--- a/apps/ades/envs/test/secrets.yaml
+++ b/apps/ades/envs/test/secrets.yaml
@@ -1,27 +1,6 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: ades
-spec:
-  refreshInterval: 1m
-  secretStoreRef:
-    name: secret-store
-    kind: ClusterSecretStore
-  target:
-    name: ades-secret
-  data:
-    - secretKey: workflowExecutor.inputs.STAGEOUT_AWS_ACCESS_KEY_ID
-      remoteRef:
-        key: eodhp-test
-        property: "ades.workflowExecutor.inputs.STAGEOUT_AWS_ACCESS_KEY_ID"
-    - secretKey: workflowExecutor.inputs.STAGEOUT_AWS_SECRET_ACCESS_KEY
-      remoteRef:
-        key: eodhp-test
-        property: "ades.workflowExecutor.inputs.STAGEOUT_AWS_SECRET_ACCESS_KEY"
----
-apiVersion: external-secrets.io/v1beta1
-kind: ExternalSecret
-metadata:
   name: basic-auth
   namespace: ades
 spec:

--- a/apps/ades/envs/test/values.yaml
+++ b/apps/ades/envs/test/values.yaml
@@ -48,7 +48,19 @@ files:
         - python
         - stageout.py
       arguments:
-        - $( inputs.wf_outputs.path )
+        - valueFrom: |
+                      ${
+                          if( !Array.isArray(inputs.wf_outputs) ) 
+                          {
+                              return inputs.wf_outputs.path;
+                          }
+                          var args=[];
+                          for (var i = 0; i < inputs.wf_outputs.length; i++) 
+                          {
+                              args.push(inputs.wf_outputs[i].path);
+                          }
+                          return args;
+                      }
         - $( inputs.STAGEOUT_OUTPUT )
         - $( inputs.process )
         - $( inputs.collection_id )
@@ -80,13 +92,9 @@ files:
                 bucket = sys.argv[2]
                 subfolder = sys.argv[3]
                 collection_id = sys.argv[4]
-                print(f"cat_url: {cat_url}", file=sys.stderr)
-                print(f"bucket: {bucket}", file=sys.stderr)
-                print(f"subfolder: {subfolder}", file=sys.stderr)
-                print(f"collection_id: {collection_id}", file=sys.stderr)
-                
-                aws_access_key_id = os.environ["AWS_ACCESS_KEY_ID"]
-                aws_secret_access_key = os.environ["AWS_SECRET_ACCESS_KEY"]
+                if os.environ["AWS_ACCESS_KEY_ID"] and os.environ["AWS_SECRET_ACCESS_KEY"]:
+                    aws_access_key_id = os.environ["AWS_ACCESS_KEY_ID"]
+                    aws_secret_access_key = os.environ["AWS_SECRET_ACCESS_KEY"]
                 region_name = os.environ["AWS_REGION"]
                 endpoint_url = os.environ["AWS_S3_ENDPOINT"]
                 print(f"aws_access_key_id: {aws_access_key_id}", file=sys.stderr)
@@ -102,14 +110,17 @@ files:
                 
                     def __init__(self):
                         self.session = botocore.session.Session()
-                        self.s3_client = self.session.create_client(
-                            service_name="s3",
-                            use_ssl=True,
-                            aws_access_key_id=aws_access_key_id,
-                            aws_secret_access_key=aws_secret_access_key,
-                            endpoint_url=endpoint_url,
-                            region_name=region_name,
-                        )
+                        if os.environ["AWS_ACCESS_KEY_ID"] and os.environ["AWS_SECRET_ACCESS_KEY"]:
+                            self.s3_client = self.session.create_client(
+                              service_name="s3",
+                              use_ssl=True,
+                              aws_access_key_id=aws_access_key_id,
+                              aws_secret_access_key=aws_secret_access_key,
+                              endpoint_url=endpoint_url,
+                              region_name=region_name,
+                            )
+                        else:
+                            self.s3_client = self.session.create_client("s3")
                 
                     def write_text(self, dest, txt, *args, **kwargs):
                         parsed = urlparse(dest)
@@ -122,15 +133,16 @@ files:
                             )
                         else:
                             super().write_text(dest, txt, *args, **kwargs)
-                
-                
-                client = boto3.client(
-                    "s3",
-                    aws_access_key_id=aws_access_key_id,
-                    aws_secret_access_key=aws_secret_access_key,
-                    endpoint_url=endpoint_url,
-                    region_name=region_name,
-                )
+                if os.environ["AWS_ACCESS_KEY_ID"] and os.environ["AWS_SECRET_ACCESS_KEY"]:
+                    client = boto3.client(
+                        "s3",
+                        aws_access_key_id=aws_access_key_id,
+                        aws_secret_access_key=aws_secret_access_key,
+                        endpoint_url=endpoint_url,
+                        region_name=region_name,
+                    )
+                else:
+                    client = boto3.client("s3")
                 
                 StacIO.set_default(CustomStacIO)
                 
@@ -208,29 +220,31 @@ workflow:
     STAGEIN_AWS_ACCESS_KEY_ID: test
     STAGEIN_AWS_SECRET_ACCESS_KEY: test
     STAGEIN_AWS_REGION: RegionOne
+    STAGEOUT_AWS_ACCESS_KEY_ID: ""
+    STAGEOUT_AWS_SECRET_ACCESS_KEY: ""
   nodeSelector:
     minikube.k8s.io/primary: "true"
   storageClass: file-storage
 ingress:
   enabled: true
-
   annotations:
     kubernetes.io/ingress.class: nginx
     ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
-    cert-manager.io/cluster-issuer: lets-encrypt
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: basic-auth
     nginx.ingress.kubernetes.io/auth-realm: "Authentication Required"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+  hosturl: https://test.eodatahub.org.uk/ades
   hosts:
-    - host: ades.test.eodhp.eco-ke-staging.com
+    - host: test.eodatahub.org.uk
       paths:
-        - path: /
+        - path: /ades(/|$)(.*)
           pathType: ImplementationSpecific
   tls:
     - hosts:
-        - ades.test.eodhp.eco-ke-staging.com
-      secretName: ades.test.eodhp.eco-ke-staging.com-tls
+        - test.eodatahub.org.uk
+      secretName: test.eodatahub.org.uk-tls
 persistence:
   procServicesStorageClass: file-storage
   storageClass: file-storage

--- a/apps/ades/envs/test/values.yaml
+++ b/apps/ades/envs/test/values.yaml
@@ -97,10 +97,6 @@ files:
                     aws_secret_access_key = os.environ["AWS_SECRET_ACCESS_KEY"]
                 region_name = os.environ["AWS_REGION"]
                 endpoint_url = os.environ["AWS_S3_ENDPOINT"]
-                print(f"aws_access_key_id: {aws_access_key_id}", file=sys.stderr)
-                print(f"aws_secret_access_key: {aws_secret_access_key}", file=sys.stderr)
-                print(f"region_name: {region_name}", file=sys.stderr)
-                print(f"endpoint_url: {endpoint_url}", file=sys.stderr)
                 
                 shutil.copytree(cat_url, "/tmp/catalog")
                 cat = pystac.read_file(os.path.join("/tmp/catalog", "catalog.json"))

--- a/apps/app-hub/envs/dev/kustomization.yaml
+++ b/apps/app-hub/envs/dev/kustomization.yaml
@@ -26,9 +26,6 @@ patches:
       - op: add
         path: /spec/ingressClassName
         value: nginx
-      - op: add
-        path: /metadata/annotations/external-dns.alpha.kubernetes.io~1hostname
-        value: "*.dev.eodatahub.org.uk"
       - op: remove
         path: /metadata/annotations/cert-manager.io~1cluster-issuer
   - target:

--- a/apps/app-hub/envs/test/kustomization.yaml
+++ b/apps/app-hub/envs/test/kustomization.yaml
@@ -11,7 +11,7 @@ helmCharts:
   - name: application-hub
     repo: https://eoepca.github.io/helm-charts/
     releaseName: app-hub
-    version: 2.0.55
+    version: 2.0.59
     valuesFile: values.yaml
     namespace: proc
 
@@ -26,9 +26,8 @@ patches:
       - op: add
         path: /spec/ingressClassName
         value: nginx
-      - op: add
-        path: /metadata/annotations/external-dns.alpha.kubernetes.io~1hostname
-        value: "*.apphub.test.eodhp.eco-ke-staging.com"
+      - op: remove
+        path: /metadata/annotations/cert-manager.io~1cluster-issuer
   - target:
       kind: PodDisruptionBudget
     patch: |-

--- a/apps/app-hub/envs/test/values.yaml
+++ b/apps/app-hub/envs/test/values.yaml
@@ -3,31 +3,33 @@ ingress:
   enabled: true
   annotations: {}
   hosts:
-    - host: apphub.test.eodhp.eco-ke-staging.com
+    - host: test.eodatahub.org.uk
       paths:
-        - path: /
+        - path: /apphub
           pathType: ImplementationSpecific
   tls:
-    - secretName: apphub.test.eodhp.eco-ke-staging.com-tls
-      hosts:
-        - apphub.test.eodhp.eco-ke-staging.com
-  clusterIssuer: lets-encrypt
+    - hosts:
+        - test.eodatahub.org.uk
+      secretName: test.eodatahub.org.uk-tls
 
 jupyterhub:
   fullnameOverride: "application-hub"
   hub:
     existingSecret: app-hub
+    baseUrl: /apphub
     extraEnv:
-      JUPYTERHUB_ENV: "dev"
-      JUPYTERHUB_SINGLE_USER_IMAGE: "eoepca/pde-container:1.0.3"
-      OAUTH_CALLBACK_URL: https://apphub.test.eodhp.eco-ke-staging.com/hub/oauth_callback
-      OAUTH2_USERDATA_URL: https://keycloak.test.eodhp.eco-ke-staging.com/realms/eodhp/protocol/openid-connect/userinfo
-      OAUTH2_TOKEN_URL: https://keycloak.test.eodhp.eco-ke-staging.com/realms/eodhp/protocol/openid-connect/token
-      OAUTH2_AUTHORIZE_URL: https://keycloak.test.eodhp.eco-ke-staging.com/realms/eodhp/protocol/openid-connect/auth
-      OAUTH_LOGOUT_REDIRECT_URL: "https://apphub.test.eodhp.eco-ke-staging.com"
-      OAUTH2_USERNAME_KEY: "preferred_username"
+      JUPYTERHUB_ENV: dev
+      BASE_URL: /apphub
+      APP_HUB_NAMESPACE: proc
+      JUPYTERHUB_SINGLE_USER_IMAGE: eoepca/pde-container:1.0.3
+      OAUTH_CALLBACK_URL: https://test.eodatahub.org.uk/apphub/hub/oauth_callback
+      OAUTH2_USERDATA_URL: https://test.eodatahub.org.uk/keycloak/realms/eodhp/protocol/openid-connect/userinfo
+      OAUTH2_TOKEN_URL: https://test.eodatahub.org.uk/keycloak/realms/eodhp/protocol/openid-connect/token
+      OAUTH2_AUTHORIZE_URL: https://test.eodatahub.org.uk/keycloak/realms/eodhp/protocol/openid-connect/auth
+      OAUTH_LOGOUT_REDIRECT_URL: "https://test.eodatahub.org.uk/apphub"
+      OAUTH2_USERNAME_KEY: preferred_username
       STORAGE_CLASS: block-storage
-      RESOURCE_MANAGER_WORKSPACE_PREFIX: "ws"
+      RESOURCE_MANAGER_WORKSPACE_PREFIX: ws
       JUPYTERHUB_CRYPT_KEY:
         valueFrom:
           secretKeyRef:

--- a/apps/eoxvs/envs/test/kustomization.yaml
+++ b/apps/eoxvs/envs/test/kustomization.yaml
@@ -28,6 +28,5 @@ patches:
   - target:
       kind: Ingress
     patch: |-
-      - op: add
+      - op: remove
         path: /metadata/annotations/cert-manager.io~1cluster-issuer
-        value: lets-encrypt

--- a/apps/eoxvs/envs/test/values.yaml
+++ b/apps/eoxvs/envs/test/values.yaml
@@ -439,17 +439,15 @@ global:
       kubernetes.io/tls-acme: "true"
       nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
       nginx.ingress.kubernetes.io/enable-cors: "true"
-      cert-manager.io/cluster-issuer: letsencrypt
     hosts:
-      - host: vs.test.eodhp.eco-ke-staging.com
+      - host: test.eodatahub.org.uk
     tls:
       - hosts:
-          - vs.test.eodhp.eco-ke-staging.com
-        secretName: vs.test.eodhp.eco-ke-staging.com-tls
-      # hosts and tls will be redefined always
+          - test.eodatahub.org.uk
+        secretName: test.eodatahub.org.uk-tls
     prefix:
-      enabled: false
-      value: ""
+      enabled: true
+      value: vs
 
 # general gdal related settings
 gdal:

--- a/apps/keycloak/envs/test/values.yaml
+++ b/apps/keycloak/envs/test/values.yaml
@@ -1,4 +1,5 @@
 global.storageClass: block-storage
+httpRelativePath: /keycloak/
 auth:
   adminUser: admin
   existingSecret: keycloak
@@ -11,9 +12,7 @@ postgresql:
 ingress:
   enabled: true
   ingressClassName: nginx
-  hostname: keycloak.test.eodhp.eco-ke-staging.com
-  annotations:
-    cert-manager.io/cluster-issuer: lets-encrypt
+  hostname: test.eodatahub.org.uk
   tls: true
 proxy: edge
 keycloakConfigCli:
@@ -44,10 +43,10 @@ keycloakConfigCli:
             "alwaysDisplayInConsole": true,
             "clientAuthenticatorType": "client-secret",
             "redirectUris": [
-              "https://apphub.test.eodhp.eco-ke-staging.com/*"
+              "https://test.eodatahub.org.uk/apphub/*"
             ],
             "webOrigins": [
-              "https://apphub.test.eodhp.eco-ke-staging.com"
+              "https://test.eodatahub.org.uk/apphub"
             ],
             "standardFlowEnabled": true,
             "implicitFlowEnabled": false,

--- a/apps/web-presence/envs/test/kustomization.yaml
+++ b/apps/web-presence/envs/test/kustomization.yaml
@@ -11,7 +11,7 @@ helmCharts:
   - name: eodhp-web-presence
     repo: oci://public.ecr.aws/n1b3o1k2/helm
     releaseName: web-presence
-    version: 0.1.2
+    version: 0.1.3
     valuesFile: values.yaml
     namespace: web
 
@@ -24,8 +24,5 @@ patches:
         path: /spec/tls
         value: 
           - hosts: 
-              - test.eodhp.eco-ke-staging.com
-            secretName: test.eodhp.eco-ke-staging.com-tls
-      - op: add
-        path: /metadata/annotations/cert-manager.io~1cluster-issuer
-        value: lets-encrypt
+              - test.eodatahub.org.uk
+            secretName: test.eodatahub.org.uk-tls

--- a/apps/web-presence/envs/test/values.yaml
+++ b/apps/web-presence/envs/test/values.yaml
@@ -1,17 +1,21 @@
-app_url: test.eodhp.eco-ke-staging.com
-image: public.ecr.aws/n1b3o1k2/eodhp-web-presence:0.1.3
+app_url: test.eodatahub.org.uk
+image: public.ecr.aws/n1b3o1k2/eodhp-web-presence:0.1.4
 
 database:
   sql_user: "admin"
   sql_password: "password"
 
 ingress:
-  host: test.eodhp.eco-ke-staging.com
+  host: test.eodatahub.org.uk
 
 eox_viewserver:
-  url: https://vs.test.eodhp.eco-ke-staging.com/
+  url: https://test.eodatahub.org.uk/vs
 
-stac_browser:
-  url: https://stac.test.eodhp.eco-ke-staging.com/v3.1.1
+resource_catalogue:
+  url: https://test.eodatahub.org.uk/stac
+  version: v3.1.1
+
+catalogue_data:
+  url: https://test.eodatahub.org.uk/catalogue-data/catalog.json
 
 storage_class: block-storage


### PR DESCRIPTION
Updates to ArgoCD app test deployments. Used compare to pull across changes to test apps while updating urls from dev.* to test.*. Please inspect your apps and make sure all changes as expected. Test platform seems to be functioning well on test.eodatahub.org.uk, and I tested what I could:
1. web presence available
2. resource catalogue updates seem to be there and dev catalogue data available as expected
3. can log into ades and get apache site
4. keycloak available
5. can log into apphub via keycloak