### PR TITLE
Bugfix/add service account for results output

### DIFF
--- a/apps/ades/envs/dev/kustomization.yaml
+++ b/apps/ades/envs/dev/kustomization.yaml
@@ -62,4 +62,11 @@ patches:
             configMapKeyRef:
               name: zoo-project-dru-zoofpm-config
               key: STAGEOUT_OUTPUT
+  - target:
+      kind: ServiceAccount
+      name: zoo-project-dru-processing-manager
+    patch: |-
+      - op: add
+        path: /metadata/annotations/eks.amazonaws.com~1role-arn
+        value: arn:aws:iam::312280911266:role/ADES-eodhp-dev-9ylvhv4X
   - path: delete-pvc-patch.yaml

--- a/apps/ades/envs/dev/kustomization.yaml
+++ b/apps/ades/envs/dev/kustomization.yaml
@@ -68,5 +68,5 @@ patches:
     patch: |-
       - op: add
         path: /metadata/annotations/eks.amazonaws.com~1role-arn
-        value: arn:aws:iam::312280911266:role/ADESProcessingManager-eodhp-dev-9ylvhv4X
+        value: arn:aws:iam::312280911266:role/ADESProcessingManager-eodhp-dev-iTfh9VYd
   - path: delete-pvc-patch.yaml

--- a/apps/ades/envs/dev/kustomization.yaml
+++ b/apps/ades/envs/dev/kustomization.yaml
@@ -68,5 +68,5 @@ patches:
     patch: |-
       - op: add
         path: /metadata/annotations/eks.amazonaws.com~1role-arn
-        value: arn:aws:iam::312280911266:role/ADES-eodhp-dev-9ylvhv4X
+        value: arn:aws:iam::312280911266:role/ADESProcessingManager-eodhp-dev-9ylvhv4X
   - path: delete-pvc-patch.yaml

--- a/apps/ades/envs/dev/values.yaml
+++ b/apps/ades/envs/dev/values.yaml
@@ -1,6 +1,6 @@
 cookiecutter:
-  templateUrl: https://github.com/UKEODHP/eoepca-proc-service-template.git
-  templateBranch: bugfix/add-service-account-for-results-output
+  templateUrl: https://github.com/EOEPCA/eoepca-proc-service-template.git
+  templateBranch: master
 zoofpm:
   image:
     tag: eoepca-092ea7a2c6823dba9c6d52c383a73f5ff92d0762

--- a/apps/ades/envs/dev/values.yaml
+++ b/apps/ades/envs/dev/values.yaml
@@ -1,6 +1,6 @@
 cookiecutter:
-  templateUrl: https://github.com/EOEPCA/eoepca-proc-service-template.git
-  templateBranch: master
+  templateUrl: https://github.com/UKEODHP/eoepca-proc-service-template.git
+  templateBranch: bugfix/add-service-account-for-results-output
 zoofpm:
   image:
     tag: eoepca-092ea7a2c6823dba9c6d52c383a73f5ff92d0762


### PR DESCRIPTION
Added AWS annotation to processing-manager service account, via kustomize, to allow top-level ADES pod to read ADES S3 bucket when processing output results. This corrects the empty response to a request for job results. Also updated cookie-cutter repository to be the updated template now forked into this repository, see [here](https://github.com/UKEODHP/eoepca-proc-service-template).