### PR TITLE
feature/EODHP-16-deploy-jupyter-notebook-to-cluster-3

### DIFF
--- a/apps/app-hub/base/cluster-role.yaml
+++ b/apps/app-hub/base/cluster-role.yaml
@@ -1,0 +1,40 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: application-hub-hub
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - namespaces
+      - persistentvolumeclaims
+      - secrets
+      - services
+    verbs:
+      - get
+      - watch
+      - list
+      - create
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - watch
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: application-hub-hub
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: application-hub-hub
+subjects:
+  - kind: ServiceAccount
+    name: application-hub-hub
+    namespace: proc

--- a/apps/app-hub/base/kustomization.yaml
+++ b/apps/app-hub/base/kustomization.yaml
@@ -5,3 +5,4 @@ namespace: proc
 
 resources:
   - namespace.yaml
+  - cluster-role.yaml

--- a/apps/app-hub/envs/dev/eodhp-config.yaml
+++ b/apps/app-hub/envs/dev/eodhp-config.yaml
@@ -5,3 +5,4 @@ metadata:
   name: application-hub-jupyter-config
 files:
   - files/jupyter_config.py
+  - files/config.yml

--- a/apps/app-hub/envs/dev/eodhp-config.yaml
+++ b/apps/app-hub/envs/dev/eodhp-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: builtin
+kind: ConfigMapGenerator
+behavior: replace
+metadata:
+  name: application-hub-jupyter-config
+files:
+  - files/jupyter_config.py

--- a/apps/app-hub/envs/dev/eodhp-config.yaml
+++ b/apps/app-hub/envs/dev/eodhp-config.yaml
@@ -1,6 +1,6 @@
 apiVersion: builtin
 kind: ConfigMapGenerator
-behavior: replace
+behavior: merge
 metadata:
   name: application-hub-jupyter-config
 files:

--- a/apps/app-hub/envs/dev/files/config.yml
+++ b/apps/app-hub/envs/dev/files/config.yml
@@ -1,0 +1,68 @@
+profiles:
+  - id: profile_studio_labs
+    groups:
+      - jupyter-lab
+    definition:
+      display_name: Workflow Analysis (JupyterLab)
+      slug: studio_labs_slug
+      default: False
+      kubespawner_override:
+        cpu_limit: 1
+        mem_limit: 4G
+        image: eoepca/iat-jupyterlab:main
+    default_url: "lab"
+    config_maps:
+      - name: aws-credentials
+        key: aws-credentials
+        mount_path: /home/jovyan/.aws/credentials
+        default_mode: "0660"
+        readonly: true
+      - name: aws-config
+        key: aws-config
+        mount_path: /home/jovyan/.aws/config
+        default_mode: "0660"
+        readonly: true
+      - name: docker-config
+        key: docker-config
+        mount_path: /home/jovyan/.docker/config.json
+        default_mode: "0660"
+        readonly: true
+      - name: new-cm
+        key: new-cm
+        mount_path: /home/jovyan/new-cm
+        default_mode: "0660"
+        readonly: true
+        content: |-
+          Hello World!
+        persist: false
+    volumes:
+      - name: volume-workspace
+        claim_name: claim-workspace
+        size: 10Gi
+        storage_class: block-storage
+        access_modes:
+          - "ReadWriteOnce"
+        volume_mount:
+          name: volume-workspace
+          mount_path: "/workspace"
+        persist: true
+    pod_env_vars:
+      A: "10"
+      B: "20"
+    node_selector:
+      role: general # node selector
+    role_bindings:
+      - name: pod_reader_role_binding
+        subjects:
+          - name: default
+            kind: ServiceAccount
+        role:
+          name: pod_reader_role
+          api_group: rbac.authorization.k8s.io
+          verbs:
+            - get
+            - list
+            - watch
+          resources:
+            - pods
+        persist: false

--- a/apps/app-hub/envs/dev/files/jupyter_config.py
+++ b/apps/app-hub/envs/dev/files/jupyter_config.py
@@ -1,0 +1,238 @@
+import glob
+import os
+import re
+import sys
+from binascii import a2b_hex
+
+from application_hub_context.app_hub_context import DefaultApplicationHubContext
+from jupyterhub.utils import url_path_join
+from oauthenticator.generic import GenericOAuthenticator
+from tornado.httpclient import AsyncHTTPClient, HTTPRequest
+from tornado.httputil import url_concat
+from traitlets import Unicode
+
+config_path = "/usr/local/etc/applicationhub/config.yml"
+configuration_directory = os.path.dirname(os.path.realpath(__file__))
+sys.path.insert(0, configuration_directory)
+
+from z2jh import (
+    get_config,
+    get_name,
+    get_name_env,
+    get_secret_value,
+    set_config_if_not_none,
+)
+
+
+def custom_options_form(spawner):
+
+    spawner.log.info("Configure profile list")
+
+    namespace = f"{resource_manager_workspace_prefix}-{spawner.user.name}"
+    workspace = DefaultApplicationHubContext(
+        namespace=namespace, spawner=spawner, config_path=config_path
+    )
+
+    spawner.profile_list = workspace.get_profile_list()
+
+    return spawner._options_form_default()
+
+
+def pre_spawn_hook(spawner):
+
+    profile_slug = spawner.user_options.get("profile", None)
+
+    env = os.environ["JUPYTERHUB_ENV"].lower()
+
+    spawner.environment["CALRISSIAN_POD_NAME"] = f"jupyter-{spawner.user.name}-{env}"
+
+    spawner.log.info(f"Using profile slug {profile_slug}")
+
+    # namespace = f"jupyter-{spawner.user.name}"
+    namespace = f"{resource_manager_workspace_prefix}-{spawner.user.name}"
+
+    workspace = DefaultApplicationHubContext(
+        namespace=namespace, spawner=spawner, config_path=config_path
+    )
+
+    workspace.initialise()
+
+    profile_id = workspace.config_parser.get_profile_by_slug(slug=profile_slug).id
+
+    default_url = workspace.config_parser.get_profile_default_url(profile_id=profile_id)
+
+    if default_url:
+        spawner.log.info(f"Setting default url to {default_url}")
+        spawner.default_url = default_url
+
+    spawner.log.info(f"env: {spawner.environment.get('JPY_DEFAULT_URL')}")
+
+
+def post_stop_hook(spawner):
+
+    # namespace = f"jupyter-{spawner.user.name}"
+    namespace = f"{resource_manager_workspace_prefix}-{spawner.user.name}"
+
+    workspace = DefaultApplicationHubContext(
+        namespace=namespace, spawner=spawner, config_path=config_path
+    )
+    spawner.log.info("Dispose in post stop hook")
+    workspace.dispose()
+
+
+# Configure JupyterHub to use the curl backend for making HTTP requests,
+# rather than the pure-python implementations. The default one starts
+# being too slow to make a large number of requests to the proxy API
+# at the rate required.
+AsyncHTTPClient.configure("tornado.curl_httpclient.CurlAsyncHTTPClient")
+
+c.ConfigurableHTTPProxy.api_url = (
+    f'http://{get_name("proxy-api")}:{get_name_env("proxy-api", "_SERVICE_PORT")}'
+)
+
+print(f"c.ConfigurableHTTPProxy.api_url = {c.ConfigurableHTTPProxy.api_url}")
+c.ConfigurableHTTPProxy.should_start = False
+
+# Don't wait at all before redirecting a spawning user to the progress page
+c.JupyterHub.tornado_settings = {
+    "slow_spawn_timeout": 0,
+}
+
+
+class EoepcaOAuthenticator(GenericOAuthenticator):
+    login_service = Unicode("EOEPCA", config=True)
+    id_token = None
+    print("LOGIN EOEPCA")
+
+    def _get_user_data(self, token_response):
+        access_token = token_response["access_token"]
+        token_type = token_response["token_type"].capitalize()
+
+        # Determine who the logged in user is
+        headers = {
+            "Accept": "application/json",
+            "User-Agent": "JupyterHub",
+            "Authorization": "{} {}".format(token_type, access_token),
+        }
+        if self.userdata_url:
+            url = url_concat(self.userdata_url, self.userdata_params)
+        else:
+            raise ValueError("Please set the OAUTH2_USERDATA_URL environment variable")
+
+        if self.userdata_token_method == "url":
+            url = url_concat(self.userdata_url, dict(access_token=access_token))
+
+        req = HTTPRequest(url, headers=headers)
+        return self.fetch(req, "fetching user data")
+
+    @staticmethod
+    def _create_auth_state(token_response, user_data_response):
+        access_token = token_response["access_token"]
+        refresh_token = token_response.get("refresh_token", None)
+        scope = token_response.get("scope", "")
+        id_token = token_response["id_token"]
+        if isinstance(scope, str):
+            scope = scope.split(" ")
+
+        return {
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+            "oauth_user": user_data_response,
+            "scope": scope,
+            "id_token": id_token,
+        }
+
+    async def pre_spawn_start(self, user, spawner):
+        """Pass upstream_token to spawner via environment variable"""
+        auth_state = await user.get_auth_state()
+        if not auth_state:
+            # auth_state not enabled
+            return
+        spawner.environment["ID_TOKEN"] = auth_state["id_token"]
+
+
+jupyterhub_env = os.environ["JUPYTERHUB_ENV"].upper()
+app_hub_namespace = os.getenv("APP_HUB_NAMESPACE", "app-hub")
+jupyterhub_hub_host = f"application-hub-hub.{app_hub_namespace}"
+jupyterhub_single_user_image = os.environ["JUPYTERHUB_SINGLE_USER_IMAGE_NOTEBOOKS"]
+
+resource_manager_workspace_prefix = os.environ["RESOURCE_MANAGER_WORKSPACE_PREFIX"]
+
+c.JupyterHub.base_url = os.getenv("BASE_URL", "/").rstrip("/") + "/"
+
+c.JupyterHub.authenticator_class = EoepcaOAuthenticator
+c.Authenticator.enable_auth_state = True
+c.Authenticator.admin_users = {"eric", "bob"}
+
+# Either, Gluu...
+# c.Authenticator.scope = 'openid email user_name is_operator'.split(' ')
+# Or, Keycloak...
+c.Authenticator.scope = "openid profile email".split(" ")
+
+c.JupyterHub.cookie_secret_file = "/srv/jupyterhub/cookie_secret"
+
+# Proxy config
+c.JupyterHub.cleanup_servers = False
+# Network
+c.JupyterHub.allow_named_servers = False
+c.JupyterHub.ip = "0.0.0.0"
+c.JupyterHub.hub_ip = "0.0.0.0"
+c.JupyterHub.hub_connect_ip = jupyterhub_hub_host
+
+# Misc
+c.JupyterHub.cleanup_servers = False
+
+# Culling
+c.JupyterHub.services = [
+    {
+        "name": "idle-culler",
+        "admin": True,
+        "command": [sys.executable, "-m", "jupyterhub_idle_culler", "--timeout=3600"],
+    }
+]
+
+# Logs
+c.JupyterHub.log_level = "DEBUG"
+
+# Spawner
+c.JupyterHub.spawner_class = "kubespawner.KubeSpawner"
+c.KubeSpawner.environment = {
+    "JUPYTER_ENABLE_LAB": "true",
+}
+
+c.KubeSpawner.uid = 1001
+c.KubeSpawner.fs_gid = 100
+c.KubeSpawner.hub_connect_ip = jupyterhub_hub_host
+
+# SecurityContext
+c.KubeSpawner.privileged = True
+c.KubeSpawner.allow_privilege_escalation = True
+
+# ServiceAccount
+c.KubeSpawner.service_account = "default"
+c.KubeSpawner.start_timeout = 60 * 10
+c.KubeSpawner.image = jupyterhub_single_user_image
+c.KubernetesSpawner.verify_ssl = True
+c.KubeSpawner.pod_name_template = (
+    "jupyter-{username}-" + os.environ["JUPYTERHUB_ENV"].lower()
+)
+
+# NodeSelector
+c.KubeSpawner.node_selector = {"kubespawner": "allowed"}
+
+# Namespace
+c.KubeSpawner.namespace = app_hub_namespace
+
+# User namespace
+c.KubeSpawner.enable_user_namespaces = True
+c.KubeSpawner.user_namespace_template = (
+    resource_manager_workspace_prefix + "-{username}"
+)
+
+c.KubeSpawner.options_form = custom_options_form
+# c.KubeSpawner.image_pull_policy = "IfNotPresent"
+c.KubeSpawner.image_pull_policy = "Always"
+
+# hooks
+c.KubeSpawner.pre_spawn_hook = pre_spawn_hook
+c.KubeSpawner.post_stop_hook = post_stop_hook

--- a/apps/app-hub/envs/dev/files/jupyter_config.py
+++ b/apps/app-hub/envs/dev/files/jupyter_config.py
@@ -1,11 +1,7 @@
-import glob
 import os
-import re
 import sys
-from binascii import a2b_hex
 
 from application_hub_context.app_hub_context import DefaultApplicationHubContext
-from jupyterhub.utils import url_path_join
 from oauthenticator.generic import GenericOAuthenticator
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest
 from tornado.httputil import url_concat
@@ -15,13 +11,7 @@ config_path = "/usr/local/etc/applicationhub/config.yml"
 configuration_directory = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, configuration_directory)
 
-from z2jh import (
-    get_config,
-    get_name,
-    get_name_env,
-    get_secret_value,
-    set_config_if_not_none,
-)
+from z2jh import get_name, get_name_env
 
 
 def custom_options_form(spawner):
@@ -48,7 +38,6 @@ def pre_spawn_hook(spawner):
 
     spawner.log.info(f"Using profile slug {profile_slug}")
 
-    # namespace = f"jupyter-{spawner.user.name}"
     namespace = f"{resource_manager_workspace_prefix}-{spawner.user.name}"
 
     workspace = DefaultApplicationHubContext(
@@ -70,7 +59,6 @@ def pre_spawn_hook(spawner):
 
 def post_stop_hook(spawner):
 
-    # namespace = f"jupyter-{spawner.user.name}"
     namespace = f"{resource_manager_workspace_prefix}-{spawner.user.name}"
 
     workspace = DefaultApplicationHubContext(
@@ -100,9 +88,9 @@ c.JupyterHub.tornado_settings = {
 
 
 class EoepcaOAuthenticator(GenericOAuthenticator):
-    login_service = Unicode("EOEPCA", config=True)
+    login_service = Unicode("UK EO DataHub", config=True)
     id_token = None
-    print("LOGIN EOEPCA")
+    print("LOGIN UK EO DataHub")
 
     def _get_user_data(self, token_response):
         access_token = token_response["access_token"]
@@ -146,7 +134,6 @@ class EoepcaOAuthenticator(GenericOAuthenticator):
         """Pass upstream_token to spawner via environment variable"""
         auth_state = await user.get_auth_state()
         if not auth_state:
-            # auth_state not enabled
             return
         spawner.environment["ID_TOKEN"] = auth_state["id_token"]
 
@@ -162,12 +149,9 @@ c.JupyterHub.base_url = os.getenv("BASE_URL", "/").rstrip("/") + "/"
 
 c.JupyterHub.authenticator_class = EoepcaOAuthenticator
 c.Authenticator.enable_auth_state = True
-c.Authenticator.admin_users = {"eric", "bob"}
+c.Authenticator.admin_users = {"admin"}
 
-# Either, Gluu...
-# c.Authenticator.scope = 'openid email user_name is_operator'.split(' ')
-# Or, Keycloak...
-c.Authenticator.scope = "openid profile email".split(" ")
+c.Authenticator.scope = "openid profile email".split(" ")  # Keycloak
 
 c.JupyterHub.cookie_secret_file = "/srv/jupyterhub/cookie_secret"
 
@@ -230,7 +214,6 @@ c.KubeSpawner.user_namespace_template = (
 )
 
 c.KubeSpawner.options_form = custom_options_form
-# c.KubeSpawner.image_pull_policy = "IfNotPresent"
 c.KubeSpawner.image_pull_policy = "Always"
 
 # hooks

--- a/apps/app-hub/envs/dev/kustomization.yaml
+++ b/apps/app-hub/envs/dev/kustomization.yaml
@@ -15,6 +15,9 @@ helmCharts:
     valuesFile: values.yaml
     namespace: proc
 
+generators:
+ - eodhp-config.yaml
+
 patches:
   - target:
       kind: Ingress


### PR DESCRIPTION
Final tweak to get apphub to work. I overrode the EOEPCA pyconfig file to update the hardcoded kubespawner label filter with one that could be applied via Terraform to the node groups.

I also added cluster role and role bindings in addition to the existing role and role binding to allow RBAC permission to create new namespaces and required resources within those namespaces. This is required for user workspaces as spearate namespaces in Kubernetes Jupyter Hub (as indicated here https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html#kubespawner.KubeSpawner.enable_user_namespaces).

I had to use a generator rather than Kustomize configMapGenerator due to order of operations. configMapGenerator merge was attempted before Helm chart inflation, so required confgiMap did not yet exist otherwise. Kustomize generators are run after helm chart inflation.

I also took this opportunity to customise the apps in EODHP app-hub. I removed everything except JupyterLab and renamed is as "Workflow Analysis (JupyterLab).

To test, reviewers can visit https://dev.eodatahub.org.uk/apphub and log in as bob. Ask me for credentials. You should be able to start a server and select Workflow Analysis. Start a session and you should get a Jupyter Notebook.