### PR TITLE
EODHP-5 - add GitHub integration keycloak configuration

### DIFF
--- a/apps/keycloak/envs/dev/values.yaml
+++ b/apps/keycloak/envs/dev/values.yaml
@@ -35,6 +35,25 @@ keycloakConfigCli:
         "requiredCredentials": [
           "password"
         ],
+        "identityProviders": [
+          {
+            "alias": "github",
+            "internalId": "ecb8e623-5126-4f28-8199-e81ce6ee574a",
+            "providerId": "github",
+            "enabled": true,
+            "updateProfileFirstLoginMode": "on",
+            "trustEmail": false,
+            "storeToken": false,
+            "addReadTokenRoleOnCreate": false,
+            "authenticateByDefault": false,
+            "linkOnly": false,
+            "firstBrokerLoginFlowAlias": "first broker login",
+            "config": {
+              "clientSecret": "**********",
+              "clientId": "c83f1231b8cdce667e8c"
+            }
+          }
+        ],
         "clients": [
           {
             "clientId": "application-hub",

--- a/apps/keycloak/envs/dev/values.yaml
+++ b/apps/keycloak/envs/dev/values.yaml
@@ -38,7 +38,6 @@ keycloakConfigCli:
         "identityProviders": [
           {
             "alias": "github",
-            "internalId": "ecb8e623-5126-4f28-8199-e81ce6ee574a",
             "providerId": "github",
             "enabled": true,
             "updateProfileFirstLoginMode": "on",


### PR DESCRIPTION
Adds GitHub SSO integration to Keycloak

Testing - log in with GitHub. If dev cluster is not set up, will require adding GitHub client secret to Keycloak manually