### PR TITLE
Updated cookiecutter template branch to be master

### DIFF
--- a/apps/ades/envs/dev/values.yaml
+++ b/apps/ades/envs/dev/values.yaml
@@ -1,6 +1,6 @@
 cookiecutter:
   templateUrl: https://github.com/UKEODHP/eoepca-proc-service-template.git
-  templateBranch: bugfix/add-service-account-for-results-output
+  templateBranch: master
 zoofpm:
   image:
     tag: eoepca-092ea7a2c6823dba9c6d52c383a73f5ff92d0762


### PR DESCRIPTION
Updated cookie cutter template branch to be 'master' now updates have been merged into that forked repository.